### PR TITLE
Make gscliauth client public

### DIFF
--- a/helm/dex-app/templates/dex-secret.yaml
+++ b/helm/dex-app/templates/dex-secret.yaml
@@ -33,8 +33,6 @@ stringData:
       name: dex-k8s-authenticator
       secret: {{ .Values.Installation.V1.Secret.OIDC.ClientSecret }}
     - id: {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.ClientID }}
-      redirectURIs:
-      - {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.Address }}
       name: gscliauth
       secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.GSCLIAuth.Secret }}
       public: true

--- a/helm/dex-app/templates/dex-secret.yaml
+++ b/helm/dex-app/templates/dex-secret.yaml
@@ -27,15 +27,17 @@ stringData:
       signingKeys: "{{ .Values.Installation.V1.GiantSwarm.OIDC.Expiry.SigningKeys }}"
       idTokens: "{{ .Values.Installation.V1.GiantSwarm.OIDC.Expiry.IdTokens }}"
     staticClients:
+    - id: {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.ClientID }}
+      public: true
+      name: gscliauth
+      secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.GSCLIAuth.Secret }}
     - id: dex-k8s-authenticator
       redirectURIs:
       - https://{{ .Values.Installation.V1.GiantSwarm.OIDC.ClientAddress }}/callback
       name: dex-k8s-authenticator
       secret: {{ .Values.Installation.V1.Secret.OIDC.ClientSecret }}
-    - id: {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.ClientID }}
-      name: gscliauth
-      secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.GSCLIAuth.Secret }}
-      public: true
+      trustedPeers:
+      - {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.ClientID }}
     connectors:
     - type: {{ .Values.Installation.V1.GiantSwarm.OIDC.Type }}
       id: {{ .Values.Installation.V1.GiantSwarm.OIDC.Type }}

--- a/helm/dex-app/templates/dex-secret.yaml
+++ b/helm/dex-app/templates/dex-secret.yaml
@@ -37,6 +37,7 @@ stringData:
       - {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.Address }}
       name: gscliauth
       secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.GSCLIAuth.Secret }}
+      public: true
     connectors:
     - type: {{ .Values.Installation.V1.GiantSwarm.OIDC.Type }}
       id: {{ .Values.Installation.V1.GiantSwarm.OIDC.Type }}

--- a/helm/dex-app/templates/dex-secret.yaml
+++ b/helm/dex-app/templates/dex-secret.yaml
@@ -32,7 +32,7 @@ stringData:
       - https://{{ .Values.Installation.V1.GiantSwarm.OIDC.ClientAddress }}/callback
       name: dex-k8s-authenticator
       secret: {{ .Values.Installation.V1.Secret.OIDC.ClientSecret }}
-    - id: {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.ClientID }}
+    - id: gscliauth
       name: gscliauth
       secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.GSCLIAuth.Secret }}
       public: true

--- a/helm/dex-app/templates/dex-secret.yaml
+++ b/helm/dex-app/templates/dex-secret.yaml
@@ -32,7 +32,7 @@ stringData:
       - https://{{ .Values.Installation.V1.GiantSwarm.OIDC.ClientAddress }}/callback
       name: dex-k8s-authenticator
       secret: {{ .Values.Installation.V1.Secret.OIDC.ClientSecret }}
-    - id: gscliauth
+    - id: {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.GSCLIAuth.ClientID }}
       name: gscliauth
       secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.GSCLIAuth.Secret }}
       public: true


### PR DESCRIPTION
Finally works!

* Make `GSCLIAuth` client public, because the secret token is not really secret (the token will be in the source code, which is open source)
https://github.com/dexidp/dex/blob/master/Documentation/custom-scopes-claims-clients.md#public-clients

* Add `GSCLIAuth` as a trusted peer of `dex-k8s-authenticator`, so it could issue tokens on behalf of  `dex-k8s-authenticator` because Kubernetes only allows ID Tokens that are issued to a single client
https://github.com/dexidp/dex/blob/master/Documentation/kubernetes.md#configuring-the-openid-connect-plugin