### PR TITLE
Use dex v2.24.0-giantswarm tag with offline_scope fix in ms connector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.8.12
+  architect: giantswarm/architect@0.10.0
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `dex` `v2.24.0-giantswarm` tag, which includes Microsoft OIDC connector `offline_scope` fix (https://github.com/dexidp/dex/pull/1441).
+
 
 ## [1.0.0] - 2020-05-05
 

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -14,7 +14,7 @@ dex:
   image:
     registry: quay.io
     name: giantswarm/dex
-    tag: v2.21.0
+    tag: v2.24.0-giantswarm
     pullPolicy: IfNotPresent
 
 extraVolumes: []


### PR DESCRIPTION
It uses manually builded app with this fix https://github.com/dexidp/dex/pull/1441
Towards https://github.com/giantswarm/giantswarm/issues/11628