### PR TITLE
Update Giant Swarm logo URL in dex

### DIFF
--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -19,7 +19,7 @@ dex:
 
 extraVolumes: []
 extraVolumeMounts: []
-logoURI: http://styleguide.io/o/giantswarm/logo_simplified/giantswarm_logo_simplified.png
+logoURI: https://s.giantswarm.io/brand/1/logo.svg
 
 Installation:
   V1:


### PR DESCRIPTION
Currently the logo URL points to non-existing resource.

![image](https://user-images.githubusercontent.com/273727/109951954-976cb580-7cde-11eb-9d6f-fc5b0369c4e3.png)

This PR updates the URL to use a target controlled by us. It also switches from PNG to SVG.