### PR TITLE
Use happa homepage as login redirect

### DIFF
--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -35,7 +35,7 @@ stringData:
     - id: {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.Happa.ClientID }}
       redirectURIs:
       - {{ .Values.Installation.V1.GiantSwarm.OIDC.StaticClients.Happa.Address }}
-      - http://localhost:7000/cp-access/callback
+      - http://localhost:7000
       name: happa
       secret: {{ .Values.Installation.V1.Secret.OIDC.StaticClients.Happa.Secret }}
     - id: dex-k8s-authenticator


### PR DESCRIPTION
Towards the `happa` login story

This is for local testing