### PR TITLE
Update logo URL

### DIFF
--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -22,7 +22,7 @@ stringData:
       skipApprovalScreen: true
     enablePasswordDB: false
     frontend:
-      logoURL: http://styleguide.io/o/giantswarm/logo_simplified/giantswarm_logo_simplified.png
+      logoURL: https://s.giantswarm.io/brand/1/logo.svg
     issuer: https://{{ .Values.Installation.V1.GiantSwarm.OIDC.IssuerAddress }}
     expiry:
       signingKeys: "{{ .Values.Installation.V1.GiantSwarm.OIDC.Expiry.SigningKeys }}"


### PR DESCRIPTION
This updates another instance of the logo URL, as the current one is a 404.