### PR TITLE
Delete OWNERS

### DIFF
--- a/helm/dex-app/OWNERS
+++ b/helm/dex-app/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- desaintmartin
-- vi7
-reviewers:
-- desaintmartin
-- vi7


### PR DESCRIPTION
Deletes the OWNERS file which was copied from upstream but has no meaning in Giant Swarm context