### PR TITLE
Update Ingress resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop support for Kubernetes < 1.19
+
 ## [1.18.0] - 2021-11-25
 
 - Enable telemetry under `/metrics` on port 5558.

--- a/helm/dex-app/Chart.yaml
+++ b/helm/dex-app/Chart.yaml
@@ -27,3 +27,4 @@ maintainers:
 annotations:
   application.giantswarm.io/team: team-rainbow
   config.giantswarm.io/version: 1.x.x
+kubeVersion: ">=1.19.0-0"

--- a/helm/dex-app/templates/dex-k8s-authenticator/certs-secret.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/certs-secret.yaml
@@ -1,13 +1,13 @@
 {{- if not .Values.ingress.tls.letsencrypt }}
 apiVersion: v1
 kind: Secret
-type: Opaque
+type: kubernetes.io/tls
 metadata:
   labels:
     {{- include "dexk8sauth.labels.common" . | nindent 4 }}
   name: {{ include "resource.dexk8sauth.name" . }}
 data:
-  ca.crt: {{ .Values.ingress.tls.caPemB64 }} 
-  tls.crt: {{ .Values.ingress.tls.crtPemB64 }} 
-  tls.key: {{ .Values.ingress.tls.keyPemB64 }} 
+  ca.crt: {{ .Values.ingress.tls.caPemB64 | quote }}
+  tls.crt: {{ .Values.ingress.tls.crtPemB64 | quote }}
+  tls.key: {{ .Values.ingress.tls.keyPemB64 | quote }}
 {{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -1,9 +1,5 @@
 {{ if or (eq (include "has-giantswarm-connector" .) "true") .Values.oidc.customer.enabled }}
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{ else }}
-apiVersion: networking.k8s.io/v1beta1
-{{ end }}
 kind: Ingress
 metadata:
   name: {{ include "resource.dexk8sauth.name" . }}
@@ -12,6 +8,7 @@ metadata:
   annotations:
     {{- if .Values.ingress.tls.letsencrypt }}
     kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
     {{- end }}
 spec:
   ingressClassName: nginx
@@ -39,15 +36,10 @@ spec:
       - path: /admin/
         pathType: Prefix
         backend:
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: {{ include "resource.dexk8sauth.name" . }}-giantswarm
             port:
               name: http
-  {{- else }}
-          serviceName: {{ include "resource.dexk8sauth.name" . }}-giantswarm
-          servicePort: http
-  {{- end }}
 {{- end }}
 {{- if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
@@ -57,29 +49,19 @@ spec:
       - path: /
         pathType: Prefix
         backend:
-  {{- if $resource.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: {{ include "resource.dexk8sauth.name" $resource }}-{{ .id }}
             port:
               name: http
-  {{- else }}
-          serviceName: {{ include "resource.dexk8sauth.name" $resource }}-{{ .id }}
-          servicePort: http
-  {{- end }}
 {{- end }}
 {{- else }}
       - path: /
         pathType: Prefix
         backend:
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: {{ include "resource.dexk8sauth.name" . }}-customer
             port:
               name: http
-  {{- else }}
-          serviceName: {{ include "resource.dexk8sauth.name" . }}-customer
-          servicePort: http
-  {{- end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/helm/dex-app/templates/dex/certs-secret.yaml
+++ b/helm/dex-app/templates/dex/certs-secret.yaml
@@ -1,12 +1,13 @@
 {{- if not .Values.ingress.tls.letsencrypt }}
 apiVersion: v1
 kind: Secret
-type: Opaque
+type: kubernetes.io/tls
 metadata:
   labels:
     {{- include "dex.labels.common" . | nindent 4 }}
   name: {{ include "resource.dex.name" . }}-tls
 data:
-  tls.crt: {{ .Values.ingress.tls.crtPemB64 | quote }} 
-  tls.key: {{ .Values.ingress.tls.keyPemB64 | quote }} 
+  ca.crt: {{ .Values.ingress.tls.caPemB64 | quote }}
+  tls.crt: {{ .Values.ingress.tls.crtPemB64 | quote }}
+  tls.key: {{ .Values.ingress.tls.keyPemB64 | quote }}
 {{- end }}

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -1,8 +1,4 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{ else }}
-apiVersion: networking.k8s.io/v1beta1
-{{ end }}
 kind: Ingress
 metadata:
   name: {{ include "resource.dex.name" . }}
@@ -37,12 +33,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ include "resource.dex.name" . }}
                 port:
                   number: 32000
-{{- else }}
-              serviceName: {{ include "resource.dex.name" . }}
-              servicePort: 32000
-{{- end }}

--- a/helm/dex-app/templates/dex/service-monitor.yaml
+++ b/helm/dex-app/templates/dex/service-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -11,3 +12,4 @@ spec:
   selector:
     matchLabels:
   {{- include "dex.labels.selector" . | nindent 6 }}
+{{- end }}


### PR DESCRIPTION
This pull request contains the following changes to the helm chart:

- Change certificate secrets to `type: kubernetes/tls`. This enables us to monitor these secrets using cert-exporter
- Remove support for Kubernetes below 1.19. (Remove Ingress networking.k8s.io/v1beta1 checks)
- Try to install the ServiceMonitor ressource only if the neccesary CRD is available

## Checklist

- [x] Update CHANGELOG.md
