### PR TITLE
Breaking: Remove unused write_all_group config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed configuration value `write_all_group` which was unused (breaking change).
 
 ## [1.22.2] - 2022-02-24
 

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -130,18 +130,12 @@
                                     },
                                     "id": {
                                         "type": "string"
-                                    },
-                                    "write_all_group": {
-                                        "type": "string"
                                     }
                                 }
                             }
                         },
                         "enabled": {
                             "type": "boolean"
-                        },
-                        "write_all_group": {
-                            "type": "string"
                         }
                     }
                 },
@@ -172,9 +166,6 @@
                                     "type": "string"
                                 }
                             }
-                        },
-                        "write_all_group": {
-                            "type": "string"
                         }
                     }
                 },

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -52,13 +52,11 @@ oidc:
       clientID: ""
       clientSecret: ""
       team: ""
-    write_all_group: ""
   customer:
     enabled: false
     connectorType: ""
     connectorName: ""
     connectorConfig: ""
-    write_all_group: ""
     connectors: []
 
 services:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19735

This removes the `write_all_group` configuration value, which is not used.

Since the property is removed from the schema, this is a breaking change. We'll have to discuss migration.

## Checklist

- [x] Update CHANGELOG.md
