### PR TITLE
Add PodDisruptionBudget

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -6,5 +6,8 @@ upgrade-tests-cluster-config-file: tests/kind_config.yaml
 upgrade-tests-app-config-file: tests/test-values.yaml
 upgrade-tests-app-catalog-url: https://giantswarm.github.io/giantswarm-playground-catalog
 
-skip-steps: [functional upgrade]
+skip-steps:
+- functional
+- upgrade
+
 app-tests-app-config-file: tests/test-values.yaml

--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -6,5 +6,5 @@ upgrade-tests-cluster-config-file: tests/kind_config.yaml
 upgrade-tests-app-config-file: tests/test-values.yaml
 upgrade-tests-app-catalog-url: https://giantswarm.github.io/giantswarm-playground-catalog
 
-skip-steps: [functional]
+skip-steps: [functional upgrade]
 app-tests-app-config-file: tests/test-values.yaml

--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -6,8 +6,6 @@ upgrade-tests-cluster-config-file: tests/kind_config.yaml
 upgrade-tests-app-config-file: tests/test-values.yaml
 upgrade-tests-app-catalog-url: https://giantswarm.github.io/giantswarm-playground-catalog
 
-skip-steps:
-- functional
-- upgrade
+skip-steps: [functional, upgrade]
 
 app-tests-app-config-file: tests/test-values.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add PodDisruptionBudget with `minAvailable: 1`
 
 ## [1.22.2] - 2022-02-24
 

--- a/helm/dex-app/templates/dex/pdb.yaml
+++ b/helm/dex-app/templates/dex/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "resource.dex.name" . }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "dex.labels.common" . | nindent 6 }}

--- a/helm/dex-app/templates/dex/pdb.yaml
+++ b/helm/dex-app/templates/dex/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -7,3 +8,4 @@ spec:
   selector:
     matchLabels:
       {{- include "dex.labels.common" . | nindent 6 }}
+{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21103

This PR adds a PodDisruptionBudget (where Kubernetes supports it) for dex. Also upgrade tests are disabled in ATS, as there is only one release currently in the catalog and they will always fail.

## Checklist

- [x] Update CHANGELOG.md
