### PR TITLE
Add default port in dex authenticator API definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default port to Kubernetes API values to make it configurable.
+
 ## [1.24.0] - 2022-03-17
 
 ### Changed

--- a/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml
@@ -29,9 +29,9 @@ data:
       connector_id: {{ .id }}
       issuer: https://{{ $values.oidc.issuerAddress }}
       {{- if $values.services.kubernetes.api.public }}
-      k8s_master_uri: {{ $values.services.kubernetes.api.address }}
+      k8s_master_uri: {{ $values.services.kubernetes.api.address }}:{{ $values.services.kubernetes.api.port }}
       {{- else }}
-      k8s_master_uri: {{ $values.services.kubernetes.api.internalAddress }}
+      k8s_master_uri: {{ $values.services.kubernetes.api.internalAddress }}:{{ $values.services.kubernetes.api.port }}
       {{- end }}
       k8s_ca_pem: {{ toYaml $values.services.kubernetes.api.caPem | indent 8 }}
       redirect_uri: https://{{ $values.oidc.staticClients.dexK8SAuthenticator.clientAddress }}/callback
@@ -44,9 +44,9 @@ data:
       connector_id: {{ .id }}
       issuer: https://dex.{{ $values.baseDomain }}
       {{- if $values.services.kubernetes.api.public }}
-      k8s_master_uri: https://api.{{ $values.baseDomain }}
+      k8s_master_uri: https://api.{{ $values.baseDomain }}:{{ $values.services.kubernetes.api.port }}
       {{- else }}
-      k8s_master_uri: {{ $values.services.kubernetes.api.internalAddress }}
+      k8s_master_uri: {{ $values.services.kubernetes.api.internalAddress }}:{{ $values.services.kubernetes.api.port }}
       {{- end }}
       k8s_ca_pem: {{ toYaml $values.clusterCA | indent 8 }}
       redirect_uri: https://login.{{ $values.baseDomain }}/callback
@@ -78,9 +78,9 @@ data:
       connector_id: customer
       issuer: https://{{ .Values.oidc.issuerAddress }}
       {{- if .Values.services.kubernetes.api.public }}
-      k8s_master_uri: {{ .Values.services.kubernetes.api.address }}
+      k8s_master_uri: {{ .Values.services.kubernetes.api.address }}:{{ .Values.services.kubernetes.api.port }}
       {{- else }}
-      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}
+      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}:{{ .Values.services.kubernetes.api.port }}
       {{- end }}
       k8s_ca_pem: {{ toYaml .Values.services.kubernetes.api.caPem | indent 8 }}
       redirect_uri: https://{{ .Values.oidc.staticClients.dexK8SAuthenticator.clientAddress }}/callback
@@ -93,9 +93,9 @@ data:
       connector_id: customer
       issuer: https://dex.{{ .Values.baseDomain }}
       {{- if .Values.services.kubernetes.api.public }}
-      k8s_master_uri: https://api.{{ .Values.baseDomain }}
+      k8s_master_uri: https://api.{{ .Values.baseDomain }}:{{ .Values.services.kubernetes.api.port }}
       {{- else }}
-      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}
+      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}:{{ .Values.services.kubernetes.api.port }}
       {{- end }}
       k8s_ca_pem: {{ toYaml .Values.clusterCA | indent 8 }}
       redirect_uri: https://login.{{ .Values.baseDomain }}/callback

--- a/helm/dex-app/templates/dex-k8s-authenticator/configmap-giantswarm.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/configmap-giantswarm.yaml
@@ -24,9 +24,9 @@ data:
       connector_id: giantswarm
       issuer: https://{{ .Values.oidc.issuerAddress }}
       {{if .Values.services.kubernetes.api.public }}
-      k8s_master_uri: {{ .Values.services.kubernetes.api.address }}
+      k8s_master_uri: {{ .Values.services.kubernetes.api.address }}:{{ .Values.services.kubernetes.api.port }}
       {{- else }}
-      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}
+      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}:{{ .Values.services.kubernetes.api.port }}
       {{- end }}
       k8s_ca_pem: {{ toYaml .Values.services.kubernetes.api.caPem | indent 8 }}
       {{- if .Values.oidc.customer.enabled }}
@@ -43,9 +43,9 @@ data:
       connector_id: giantswarm
       issuer: https://dex.{{ .Values.baseDomain }}
       {{if .Values.services.kubernetes.api.public }}
-      k8s_master_uri: https://api.{{ .Values.baseDomain }}
+      k8s_master_uri: https://api.{{ .Values.baseDomain }}:{{ .Values.services.kubernetes.api.port }}
       {{- else }}
-      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}
+      k8s_master_uri: {{ .Values.services.kubernetes.api.internalAddress }}:{{ .Values.services.kubernetes.api.port }}
       {{- end }}
       k8s_ca_pem: {{ toYaml .Values.services.kubernetes.api.caPem | indent 8 }}
       {{- if .Values.oidc.customer.enabled }}

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -276,6 +276,9 @@
                                 },
                                 "public": {
                                     "type": "boolean"
+                                },
+                                "port": {
+                                    "type": "string"
                                 }
                             }
                         }

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -278,7 +278,7 @@
                                     "type": "boolean"
                                 },
                                 "port": {
-                                    "type": "string"
+                                    "type": "integer"
                                 }
                             }
                         }

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -68,6 +68,7 @@ services:
       address: ""
       internalAddress: ""
       caPem: ""
+      port: 443
   happa:
     address: ""
   grafana:


### PR DESCRIPTION
Adding a default port for Kubernetes API definition to make it configurable. In some environments, we don't use default `443`

## Checklist

- [x] Update CHANGELOG.md
