### PR TITLE
allow-configuration-of-cluster-issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add option to configure custom clusterIssuer for certificate generation.
+
 ## [1.30.2] - 2022-11-24
 
 ## Added

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
@@ -82,6 +82,15 @@ spec:
         configMap:
           name: {{ include "resource.dexk8sauth.name" . }}-giantswarm
       {{- if not .Values.ingress.tls.letsencrypt }}
+      {{- if ne .Values.ingress.tls.clusterIssuer "" }
+      - secret:
+          defaultMode: 420
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: {{ include "resource.dex.name" . }}-tls
+        name: ca-cert
+      {{- else }}
       - secret:
           defaultMode: 420
           items:

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
@@ -82,7 +82,7 @@ spec:
         configMap:
           name: {{ include "resource.dexk8sauth.name" . }}-giantswarm
       {{- if not .Values.ingress.tls.letsencrypt }}
-      {{- if ne .Values.ingress.tls.clusterIssuer "" }
+      {{- if ne .Values.ingress.tls.clusterIssuer "" }}
       - secret:
           defaultMode: 420
           items:

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
@@ -99,4 +99,5 @@ spec:
           secretName: {{ include "resource.dexk8sauth.name" . }}
         name: ca-cert
       {{- end }}
+      {{- end }}
 {{ end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -11,8 +11,9 @@ metadata:
     {{- include "dexk8sauth.labels.common" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.tls.letsencrypt }}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+    {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
 spec:
   ingressClassName: nginx

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -10,8 +10,9 @@ metadata:
     {{- include "dex.labels.common" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.tls.letsencrypt }}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+    {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
 spec:
   ingressClassName: nginx

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -61,6 +61,9 @@
                         "caPemB64": {
                             "type": "string"
                         },
+			"clusterIssuer": {
+                            "type": "string"
+                        },
                         "crtPemB64": {
                             "type": "string"
                         },

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -24,6 +24,7 @@ logoURI: https://s.giantswarm.io/brand/1/logo.svg
 ingress:
   tls:
     letsencrypt: true
+    clusterIssuer: ""
     caPemB64: ""
     crtPemB64: ""
     keyPemB64: ""


### PR DESCRIPTION
necessary for private MCs where certs are issued by private CA but managed by cert-manager

test on fully private MC