### PR TITLE
do not override old connector attribute with new connectors array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- If more connectors are specified in `Values.oidc.customer.connectors` in addition to an existing one in `Values.oidc.customer.connectorConfig`, include both in the dex secret.
+
 ## [1.30.2] - 2022-11-24
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.2] - 2022-11-24
+
 ## Added
 
 - Added support for polymorphic values of `managementCluster` - it can be defined either as `string` or as `object`.
@@ -359,7 +361,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add helm chart for dex.
 
 
-[Unreleased]: https://github.com/giantswarm/dex-app/compare/v1.30.1...HEAD
+[Unreleased]: https://github.com/giantswarm/dex-app/compare/v1.30.2...HEAD
+[1.30.2]: https://github.com/giantswarm/dex-app/compare/v1.30.1...v1.30.2
 [1.30.1]: https://github.com/giantswarm/dex-app/compare/v1.30.0...v1.30.1
 [1.30.0]: https://github.com/giantswarm/dex-app/compare/v1.29.0...v1.30.0
 [1.29.0]: https://github.com/giantswarm/dex-app/compare/v1.28.0...v1.29.0

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -126,7 +126,8 @@ stringData:
       config:
         {{- .connectorConfig | nindent 8 }}
     {{- end }}
-    {{- else }}
+    {{- end }}
+    {{- if .Values.oidc.customer.connectorConfig }}
     - type: {{ .Values.oidc.customer.connectorType }}
       id: customer
       name: {{ .Values.oidc.customer.connectorName }}

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -47,7 +47,7 @@ def test_cluster_info(
 def app_deployment(kube_cluster: Cluster) -> List[pykube.Deployment]:
     deployments = wait_for_deployments_to_run(
         kube_cluster.kube_client,
-        ["dex", "dex-k8s-authenticator-customer"],
+        ["dex"],
         "default",
         timeout,
     )

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -16,9 +16,13 @@ oidc:
       clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
   customer:
     enabled: true
+    connectorType: testtype
+    connectorName: testname
+    connectorConfig: |-
+      test: test
     connectors:
       - connectorType: mockCallback
-        id: customer
+        id: customer-2
         connectorName: Kubernetes Dev Cluster
         connectorConfig: |-
           clientID: example-cluster-client-id
@@ -30,9 +34,13 @@ oidc:
           issuer: http://127.0.0.1:5556
           redirectURI: http://127.0.0.1:5555/callback/example-cluster
   giantswarm:
+    connectorConfig:
+      clientID: id
+      clientSecret: secret
+      team: gs
     connectors:
       - connectorType: mockCallback
-        id: giantswarm
+        id: giantswarm-2
         connectorName: Kubernetes Dev Cluster
         connectorConfig: |-
           clientID: example-client-id
@@ -43,3 +51,9 @@ oidc:
           - profile
           issuer: http://127.0.0.1:5556
           redirectURI: http://127.0.0.1:5555/callback/example-cluster
+      - connectorType: testtest
+        id: giantswarm-3
+        connectorName: something
+        connectorConfig: |-
+          test: test
+

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -16,7 +16,7 @@ oidc:
       clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
   customer:
     enabled: true
-    connectorType: testtype
+    connectorType: mockCallback
     connectorName: testname
     connectorConfig: |-
       test: test
@@ -51,7 +51,7 @@ oidc:
           - profile
           issuer: http://127.0.0.1:5556
           redirectURI: http://127.0.0.1:5555/callback/example-cluster
-      - connectorType: testtest
+      - connectorType: mockCallback
         id: giantswarm-3
         connectorName: something
         connectorConfig: |-


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1596
If more connectors are specified in `Values.oidc.customer.connectors` in addition to an existing one in `Values.oidc.customer.connectorConfig`, include both in the dex secret instead of overriding.



## Checklist

- [ ] Update CHANGELOG.md
