### PR TITLE
Fix allowPrivilegeEscalation securityContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix deployment template securityContext.
+
 ## [1.31.0] - 2022-11-29
 
 ### Added

--- a/helm/dex-app/templates/dex/deployment.yaml
+++ b/helm/dex-app/templates/dex/deployment.yaml
@@ -33,7 +33,6 @@ spec:
             weight: 100
       serviceAccountName: {{ include "resource.dex.name" . }}
       securityContext:
-        allowPrivilegeEscalation: false
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
@@ -61,6 +60,8 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         ports:
         - name: http
           containerPort: 5556


### PR DESCRIPTION
ℹ️  For some reason `allowPrivilegeEscalation` was set on PodSecuriyContext level, whereas the truth is there's no such variable.
Ref: [PodSecurityContext](https://pkg.go.dev/k8s.io/api/core/v1#PodSecurityContext)

💡  `allowPrivilegeEscalation`  must be set on Container SecuriyContext ✅ 
Ref: [SecurityContext](https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext)


## Checklist

- [X] Update CHANGELOG.md
