### PR TITLE
Use image from re-usable schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use external [image](https://schema.giantswarm.io/image/v0.0.1) schema.
+
 ## [1.31.2] - 2022-12-01
 
 ### Added

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -1,26 +1,12 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "client": {
             "type": "object",
             "properties": {
                 "image": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "registry": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
+                    "$ref": "https://schema.giantswarm.io/image/v0.0.1"
                 }
             }
         },
@@ -28,21 +14,7 @@
             "type": "object",
             "properties": {
                 "image": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "registry": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
+                    "$ref": "https://schema.giantswarm.io/image/v0.0.1"
                 }
             }
         },


### PR DESCRIPTION
This PR uses the external schema https://schema.giantswarm.io/image/v0.0.1 for image definitions. This is a purely technical change which does not modify the resulting schema.

## Checklist

- [x] Update CHANGELOG.md
