### PR TITLE
Allowed null values of OIDC connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use external [image](https://schema.giantswarm.io/image/v0.0.1) schema.
+- Allowed null values of OIDC connectors in the values schema
 
 ## [1.31.2] - 2022-12-01
 

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -82,7 +82,7 @@
                             "type": "string"
                         },
                         "connectors": {
-                            "type": "array",
+                            "type": ["array", "null"],
                             "items": {
                                 "type": "object",
                                 "properties": {
@@ -141,7 +141,7 @@
                             }
                         },
                         "connectors": {
-                            "type": "array",
+                            "type": ["array", "null"],
                             "items": {
                                 "type": "object",
                                 "properties": {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/roadmap/issues/1802

Dex operator may create a configuration with the value of `oidc.customer.connectors` set to `null`. This is not supported in the values schema, and therefore the deployment of Dex app with such configuration fails.

It is safe to provide `null` values for connectors, therefore this PR adds support for that to the values schema.

## Checklist

- [x] Update CHANGELOG.md
