### PR TITLE
Improve dex login and error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improve connector selection (login) and error page UI.
+
 ## [1.32.1] - 2022-12-22
 
 ### Changed

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -6,8 +6,14 @@ body {
   margin: 0;
 }
 
+code {
+  font-size: 90%;
+  font-weight: 400;
+}
+
 .dex-container {
   color: #333;
+  font-size: 16px;
   margin: 45px auto;
   max-width: 500px;
   min-width: 320px;
@@ -21,6 +27,7 @@ body {
   cursor: pointer;
   font-size: 16px;
   padding: 0;
+  width: 100%
 }
 
 .dex-btn:focus {
@@ -106,10 +113,16 @@ body {
 }
 
 .dex-btn-text {
+  display: flex;
+  flex-direction: column;
   font-weight: 600;
-  line-height: 36px;
-  padding: 6px 12px;
+  line-height: 20px;
+  padding: 8px 12px 4px;
   text-align: center;
+}
+
+.dex-btn-text > code {
+  line-height: 30px;
 }
 
 .dex-subtle-text {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -28,7 +28,7 @@ code {
   cursor: pointer;
   font-size: 16px;
   padding: 0;
-  width: 100%
+  width: 100%;
 }
 
 .dex-btn:focus {

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -7,6 +7,7 @@ body {
 }
 
 code {
+  color: #666;
   font-size: 90%;
   font-weight: 400;
 }

--- a/web/templates/error.html
+++ b/web/templates/error.html
@@ -9,24 +9,35 @@
 <script>
   const errorMsg = {{ .ErrMsg }};
   const connectorID = new URL(document.location).searchParams.get(
-      "connector_id"
+    'connector_id'
   );
-  const errorContainerEl = document.querySelector("#error");
+  const errorContainerEl = document.querySelector('#error');
 
-  if (connectorID && errorMsg === "Connector ID does not match a valid Connector") {
-      const errorMsgEl = document.createElement("p");
-      errorMsgEl.textContent = `Connector ID "${connectorID}" does not match a valid connector.`;
-
-      errorContainerEl.append(errorMsgEl);
+  if (
+    connectorID &&
+    errorMsg === 'Connector ID does not match a valid Connector'
+  ) {
+    const errorMsgConnectorID = document.createElement('code');
+    errorMsgConnectorID.textContent = connectorID;
+    const errorMsgEl = document.createElement('h3');
+    errorMsgEl.classList.add('theme-heading');
+    errorMsgEl.append(
+      document.createTextNode('There is no connector matching the ID '),
+      errorMsgConnectorID
+    );
+    const errorMsgDetailsEl = document.createElement('p');
+    errorMsgDetailsEl.textContent =
+      'To see a list of all configured connectors, please try logging in without specifying a connector ID.';
+    errorContainerEl.append(errorMsgEl, errorMsgDetailsEl);
   } else {
-      const errorTypeEl = document.createElement("h2");
-      errorTypeEl.classList.add("theme-heading");
-      errorTypeEl.textContent = {{ .ErrType }};
+    const errorTypeEl = document.createElement('h2');
+    errorTypeEl.classList.add('theme-heading');
+    errorTypeEl.textContent = {{ .ErrType }};
 
-      const errorMsgEl = document.createElement("p");
-      errorMsgEl.textContent = errorMsg;
+    const errorMsgEl = document.createElement('p');
+    errorMsgEl.textContent = errorMsg;
 
-      errorContainerEl.append(errorTypeEl, errorMsgEl);
+    errorContainerEl.append(errorTypeEl, errorMsgEl);
   }
 </script>
 

--- a/web/templates/error.html
+++ b/web/templates/error.html
@@ -1,8 +1,33 @@
 {{ template "header.html" . }}
 
-<div class="theme-panel">
-  <h2 class="theme-heading">{{ .ErrType }}</h2>
-  <p>{{ .ErrMsg }}</p>
+<div class="theme-panel" id="error">
+  <noscript>
+    <h2 class="theme-heading">{{ .ErrType }}</h2>
+    <p>{{ .ErrMsg }}</p>
+  </noscript>
 </div>
+<script>
+  const errorMsg = {{ .ErrMsg }};
+  const connectorID = new URL(document.location).searchParams.get(
+      "connector_id"
+  );
+  const errorContainerEl = document.querySelector("#error");
+
+  if (connectorID && errorMsg === "Connector ID does not match a valid Connector") {
+      const errorMsgEl = document.createElement("p");
+      errorMsgEl.textContent = `Connector ID "${connectorID}" does not match a valid connector.`;
+
+      errorContainerEl.append(errorMsgEl);
+  } else {
+      const errorTypeEl = document.createElement("h2");
+      errorTypeEl.classList.add("theme-heading");
+      errorTypeEl.textContent = {{ .ErrType }};
+
+      const errorMsgEl = document.createElement("p");
+      errorMsgEl.textContent = errorMsg;
+
+      errorContainerEl.append(errorTypeEl, errorMsgEl);
+  }
+</script>
 
 {{ template "footer.html" . }}

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -46,7 +46,7 @@
        buttonIcon.classList.add("dex-btn-icon", `dex-btn-icon--${c.type}`);
        const buttonText = document.createElement("span");
        buttonText.classList.add("dex-btn-text");
-       buttonText.textContent = `Log in with ${c.name}`;
+       buttonText.textContent = `Log in with ${c.name} (${c.id})`;
        buttonEl.append(buttonIcon, buttonText);
        linkEl.append(buttonEl);
        rowEl.append(linkEl);

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -27,14 +27,12 @@
               type: {{ $c.Type }}
           },{{ end }}
       ];
-
       const connectorFilter = new URL(document.location).searchParams.get(
           "connector_filter"
       );
       const filteredConnectors = connectors.filter((c) =>
           c.id.startsWith(connectorFilter)
       );
-
       const connectorsContainer = document.querySelector("#connectors");
 
       if (connectorFilter && filteredConnectors.length === 0) {

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -19,51 +19,61 @@
 </div>
 <script>
   (() => {
-      const connectors = [{{ range $c := .Connectors }}
-          {
-              id: {{ $c.ID }},
-              name: {{ $c.Name}},
-              url: {{ $c.URL }},
-              type: {{ $c.Type }}
-          },{{ end }}
-      ];
-      const connectorFilter = new URL(document.location).searchParams.get(
-          "connector_filter"
+    const connectors = [{{ range $c := .Connectors }}
+      {
+          id: {{ $c.ID }},
+          name: {{ $c.Name}},
+          url: {{ $c.URL }},
+          type: {{ $c.Type }}
+      },{{ end }}
+    ];
+    const connectorFilter = new URL(document.location).searchParams.get(
+      'connector_filter'
+    );
+    const filteredConnectors = connectors.filter((c) =>
+      c.id.startsWith(connectorFilter)
+    );
+    const connectorsContainer = document.querySelector('#connectors');
+
+    if (connectorFilter && filteredConnectors.length === 0) {
+      const emptyConnectorMsgEl = document.createElement('p');
+      const emptyConnectorMsgConnectorFilter = document.createElement('code');
+      emptyConnectorMsgConnectorFilter.textContent = connectorFilter;
+      emptyConnectorMsgEl.append(
+        document.createTextNode('No connectors matching the filter '),
+        emptyConnectorMsgConnectorFilter,
+        document.createTextNode(' were found.')
       );
-      const filteredConnectors = connectors.filter((c) =>
-          c.id.startsWith(connectorFilter)
-      );
-      const connectorsContainer = document.querySelector("#connectors");
+      connectorsContainer.append(emptyConnectorMsgEl);
+    }
 
-      if (connectorFilter && filteredConnectors.length === 0) {
-          const emptyConnectorMessageEl = document.createElement("span");
-          emptyConnectorMessageEl.textContent = `No connectors matching the filter "${connectorFilter}" were found.`;
-          connectorsContainer.append(emptyConnectorMessageEl);
-      }
+    const connectorEls = (
+      filteredConnectors.length === 0 ? connectors : filteredConnectors
+    ).map((c) => {
+      const rowEl = document.createElement('div');
+      rowEl.classList.add('theme-form-row');
+      const linkEl = document.createElement('a');
+      linkEl.href = c.url;
+      linkEl.target = '_self';
+      const buttonEl = document.createElement('button');
+      buttonEl.classList.add('dex-btn', 'theme-btn-provider');
+      const buttonIcon = document.createElement('span');
+      buttonIcon.classList.add('dex-btn-icon', `dex-btn-icon--${c.type}`);
+      const buttonContent = document.createElement('span');
+      buttonContent.classList.add('dex-btn-text');
+      const buttonContentText = document.createElement('span');
+      buttonContentText.textContent = `Log in with ${c.name}`;
+      const buttonContentConnectorID = document.createElement('code');
+      buttonContentConnectorID.textContent = c.id;
+      buttonContent.append(buttonContentText, buttonContentConnectorID);
+      buttonEl.append(buttonIcon, buttonContent);
+      linkEl.append(buttonEl);
+      rowEl.append(linkEl);
 
-      const connectorEls = (
-          filteredConnectors.length === 0 ? connectors : filteredConnectors
-      ).map((c) => {
-          const rowEl = document.createElement("div");
-          rowEl.classList.add("theme-form-row");
-          const linkEl = document.createElement("a");
-          linkEl.href = c.url;
-          linkEl.target = "_self";
-          const buttonEl = document.createElement("button");
-          buttonEl.classList.add("dex-btn", "theme-btn-provider");
-          const buttonIcon = document.createElement("span");
-          buttonIcon.classList.add("dex-btn-icon", `dex-btn-icon--${c.type}`);
-          const buttonText = document.createElement("span");
-          buttonText.classList.add("dex-btn-text");
-          buttonText.textContent = `Log in with ${c.name} (${c.id})`;
-          buttonEl.append(buttonIcon, buttonText);
-          linkEl.append(buttonEl);
-          rowEl.append(linkEl);
+      return rowEl;
+    });
 
-          return rowEl;
-      });
-
-      connectorsContainer.append(...connectorEls);
+    connectorsContainer.append(...connectorEls);
   })();
 </script>
 

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -19,43 +19,54 @@
 </div>
 <script>
   (() => {
-     const connectors = [{{ range $c := .Connectors }}
-       {
-         id: {{ $c.ID }},
-         name: {{ $c.Name}},
-         url: {{ $c.URL }},
-         type: {{ $c.Type }}
-       },{{ end }}
-     ];
+      const connectors = [{{ range $c := .Connectors }}
+          {
+              id: {{ $c.ID }},
+              name: {{ $c.Name}},
+              url: {{ $c.URL }},
+              type: {{ $c.Type }}
+          },{{ end }}
+      ];
 
-     const connectorFilter = (new URL(document.location)).searchParams.get("connector_filter");
-     const connectorEls = [];
+      const connectorFilter = new URL(document.location).searchParams.get(
+          "connector_filter"
+      );
+      const filteredConnectors = connectors.filter((c) =>
+          c.id.startsWith(connectorFilter)
+      );
 
-     for (const c of connectors) {
-       if (connectorFilter && !c.id.startsWith(connectorFilter)) {
-         continue;
-       }
-       const rowEl = document.createElement("div");
-       rowEl.classList.add("theme-form-row");
-       const linkEl = document.createElement("a");
-       linkEl.href = c.url;
-       linkEl.target = "_self";
-       const buttonEl = document.createElement("button");
-       buttonEl.classList.add("dex-btn", "theme-btn-provider");
-       const buttonIcon = document.createElement("span");
-       buttonIcon.classList.add("dex-btn-icon", `dex-btn-icon--${c.type}`);
-       const buttonText = document.createElement("span");
-       buttonText.classList.add("dex-btn-text");
-       buttonText.textContent = `Log in with ${c.name} (${c.id})`;
-       buttonEl.append(buttonIcon, buttonText);
-       linkEl.append(buttonEl);
-       rowEl.append(linkEl);
-       connectorEls.push(rowEl);
-     }
+      const connectorsContainer = document.querySelector("#connectors");
 
-     const connectorsContainer = document.querySelector("#connectors");
-     connectorsContainer.append(...connectorEls);
-   })();
+      if (connectorFilter && filteredConnectors.length === 0) {
+          const emptyConnectorMessageEl = document.createElement("span");
+          emptyConnectorMessageEl.textContent = `No connectors matching the filter "${connectorFilter}" were found.`;
+          connectorsContainer.append(emptyConnectorMessageEl);
+      }
+
+      const connectorEls = (
+          filteredConnectors.length === 0 ? connectors : filteredConnectors
+      ).map((c) => {
+          const rowEl = document.createElement("div");
+          rowEl.classList.add("theme-form-row");
+          const linkEl = document.createElement("a");
+          linkEl.href = c.url;
+          linkEl.target = "_self";
+          const buttonEl = document.createElement("button");
+          buttonEl.classList.add("dex-btn", "theme-btn-provider");
+          const buttonIcon = document.createElement("span");
+          buttonIcon.classList.add("dex-btn-icon", `dex-btn-icon--${c.type}`);
+          const buttonText = document.createElement("span");
+          buttonText.classList.add("dex-btn-text");
+          buttonText.textContent = `Log in with ${c.name} (${c.id})`;
+          buttonEl.append(buttonIcon, buttonText);
+          linkEl.append(buttonEl);
+          rowEl.append(linkEl);
+
+          return rowEl;
+      });
+
+      connectorsContainer.append(...connectorEls);
+  })();
 </script>
 
 {{ template "footer.html" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1592.

This PR brings some improvements to dex's login and error pages as suggested in https://github.com/giantswarm/roadmap/issues/1592#issuecomment-1359210510 in the following ways:

### Display connector ID in the connector selection page as additional information
<img width="600" alt="Screenshot 2023-01-13 at 10 39 16" src="https://user-images.githubusercontent.com/62935115/212288028-d54ceb2e-f88e-4f65-8347-a7ad638f4e42.png">

### Handle case when no connectors match the given `connector_filter`
If no connectors match the given `connector_filter`, the filter value is displayed, and a list of all connectors is displayed. E.g. `connector_filter=foo`:
<img width="600" alt="Screenshot 2023-01-13 at 10 38 37" src="https://user-images.githubusercontent.com/62935115/212288034-4bb0266d-b4e0-4adb-95ca-9155d9ba1ee6.png">

### Improve error page when the given `connector_id` does not match any connectors
If the given `connector_id` does not match any existing connectors, we display the following message including the provided `connector_id`. E.g. `connector_id=foo`:
<img width="600" alt="Screenshot 2023-01-13 at 10 38 17" src="https://user-images.githubusercontent.com/62935115/212288036-c141daeb-b861-49e9-85b7-7738f89c5b82.png">
Unfortunately it is not possible to display a list of connectors on the error page without modifying dex's server code. We only have access to the error type and error message.

## Checklist

- [x] Update CHANGELOG.md
