### PR TITLE
Proxy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add a possibility to configure a custom trusted root CA
+- Add support for manual configuration of private workload cluster proxy
 
 ## [1.32.2] - 2023-01-13
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ trustedRootCA:
   secretName: "name-of-the-custom-ca-secret"
 ```
 
+### Proxy configuration
+
+In case the traffic to Dex needs to go through a proxy (for example when the app is installed in a private cluster), the individual components of the app need to be set up to use the proxy.
+
+The proxy setup can be provided to the app in a specific section of the user values configmap or secret with the app configuration:
+
+```yaml
+proxy:
+  enabled: false
+  http_proxy: "https://proxy.host:4040" # hostname of the proxy for HTTP traffic
+  https_proxy: "https://proxy.host:4040" # hostname of the proxy for HTTPS traffic
+  no_proxy: "kubernetes-api-ip-range" # comma-separated list of hostnames and IP ranges, whose traffic should not go through the proxy. # Kubernetes API IP range needs to be defined here in order for Dex to work correctly
+```
 
 ## Update Process
 

--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -81,3 +81,22 @@ Abstract the knowledge to know if it needs a Giant Swarm connector or not
   {{- printf "false" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Aggregated values for NO_PROXY evn variable in the Dex deployment
+- service CIDR or fallback to default
+- pod CIDR or fallback to default
+- vpc CIDR if available
+- proxy.no_proxy if available
+*/}}
+{{- define "no-proxy-value" -}}
+  {{- if .Values.proxy }}
+    {{- $defaultNetwork := dict "serviceCIDR" "172.31.0.0/16" "podCIDR" "100.64.0.0/12" -}}
+    {{- $network := default $defaultNetwork .Values.network -}}
+    {{- $list := list (default $defaultNetwork.serviceCIDR $network.serviceCIDR) -}}
+    {{- $list = append $list (default $defaultNetwork.podCIDR $network.podCIDR) -}}
+    {{- $list = append $list (default "" $network.vpcCIDR) -}}
+    {{- $list = append $list (default "" .Values.proxy.no_proxy) -}}
+    {{- join "," (compact $list) -}}
+  {{- end -}}
+{{- end -}}

--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -81,22 +81,3 @@ Abstract the knowledge to know if it needs a Giant Swarm connector or not
   {{- printf "false" }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Aggregated values for NO_PROXY evn variable in the Dex deployment
-- service CIDR or fallback to default
-- pod CIDR or fallback to default
-- vpc CIDR if available
-- proxy.no_proxy if available
-*/}}
-{{- define "no-proxy-value" -}}
-  {{- if .Values.proxy }}
-    {{- $defaultNetwork := dict "serviceCIDR" "172.31.0.0/16" "podCIDR" "100.64.0.0/12" -}}
-    {{- $network := default $defaultNetwork .Values.network -}}
-    {{- $list := list (default $defaultNetwork.serviceCIDR $network.serviceCIDR) -}}
-    {{- $list = append $list (default $defaultNetwork.podCIDR $network.podCIDR) -}}
-    {{- $list = append $list (default "" $network.vpcCIDR) -}}
-    {{- $list = append $list (default "" .Values.proxy.no_proxy) -}}
-    {{- join "," (compact $list) -}}
-  {{- end -}}
-{{- end -}}

--- a/helm/dex-app/templates/dex/deployment.yaml
+++ b/helm/dex-app/templates/dex/deployment.yaml
@@ -40,10 +40,25 @@ spec:
       containers:
       - name: dex
         env:
-          - name: KUBERNETES_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+        {{- if .Values.proxy }}
+        {{- if .Values.proxy.http_proxy }}
+        - name: HTTP_PROXY
+          value: {{ .Values.proxy.http_proxy }}
+        {{- end }}
+        {{- if .Values.proxy.https_proxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.proxy.https_proxy }}
+        {{- end }}
+        {{- $noProxy := include "no-proxy-value" . }}
+        {{- if not (empty $noProxy) }}
+        - name: NO_PROXY
+          value: {{ $noProxy }}
+        {{- end }}
+        {{- end }}
+        - name: KUBERNETES_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{ if .Values.isManagementCluster }}
         image: "{{ .Values.registry.domain }}/{{ .Values.dex.image.name }}:{{ .Chart.AppVersion }}"
         {{ else }}

--- a/helm/dex-app/templates/dex/deployment.yaml
+++ b/helm/dex-app/templates/dex/deployment.yaml
@@ -40,18 +40,18 @@ spec:
       containers:
       - name: dex
         env:
-        {{- if and .Values.cluster .Values.cluster.proxy }}
-        {{- if .Values.cluster.proxy.http_proxy }}
+        {{- if and .Values.proxy .Values.proxy.enabled }}
+        {{- if .Values.proxy.http_proxy }}
         - name: HTTP_PROXY
-          value: {{ .Values.cluster.proxy.http_proxy }}
+          value: {{ .Values.proxy.http_proxy }}
         {{- end }}
-        {{- if .Values.cluster.proxy.https_proxy }}
+        {{- if .Values.proxy.https_proxy }}
         - name: HTTPS_PROXY
-          value: {{ .Values.cluster.proxy.https_proxy }}
+          value: {{ .Values.proxy.https_proxy }}
         {{- end }}
-        {{- if .Values.cluster.proxy.no_proxy }}
+        {{- if .Values.proxy.no_proxy }}
         - name: NO_PROXY
-          value: {{ .Values.cluster.proxy.no_proxy }}
+          value: {{ .Values.proxy.no_proxy }}
         {{- end }}
         {{- end }}
         - name: KUBERNETES_POD_NAMESPACE

--- a/helm/dex-app/templates/dex/deployment.yaml
+++ b/helm/dex-app/templates/dex/deployment.yaml
@@ -40,19 +40,18 @@ spec:
       containers:
       - name: dex
         env:
-        {{- if .Values.proxy }}
-        {{- if .Values.proxy.http_proxy }}
+        {{- if and .Values.cluster .Values.cluster.proxy }}
+        {{- if .Values.cluster.proxy.http_proxy }}
         - name: HTTP_PROXY
-          value: {{ .Values.proxy.http_proxy }}
+          value: {{ .Values.cluster.proxy.http_proxy }}
         {{- end }}
-        {{- if .Values.proxy.https_proxy }}
+        {{- if .Values.cluster.proxy.https_proxy }}
         - name: HTTPS_PROXY
-          value: {{ .Values.proxy.https_proxy }}
+          value: {{ .Values.cluster.proxy.https_proxy }}
         {{- end }}
-        {{- $noProxy := include "no-proxy-value" . }}
-        {{- if not (empty $noProxy) }}
+        {{- if .Values.cluster.proxy.no_proxy }}
         - name: NO_PROXY
-          value: {{ $noProxy }}
+          value: {{ .Values.cluster.proxy.no_proxy }}
         {{- end }}
         {{- end }}
         - name: KUBERNETES_POD_NAMESPACE

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -336,6 +336,33 @@
                     }
                 }
             }
+        },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "proxy": {
+                    "type": "object",
+                    "title": "Schema for private workload cluster proxy setup",
+                    "properties": {
+                        "http_proxy": {
+                            "description": "base URL of the proxy for HTTP traffic (https://hostname:8080)",
+                            "type": "string"
+                        },
+                        "https_proxy": {
+                            "description": "base URL of the proxy for HTTPS traffic (https://hostname:8080)",
+                            "type": "string"
+                        },
+                        "no_proxy": {
+                            "description": "comma-separated list of IP ranges and hostnames, which should not go through the proxy",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "https_proxy",
+                        "no_proxy"
+                    ]
+                }
+            }
         }
     }
 }

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -337,32 +337,31 @@
                 }
             }
         },
-        "cluster": {
+        "proxy": {
             "type": "object",
+            "title": "Schema for private workload cluster proxy setup",
             "properties": {
-                "proxy": {
-                    "type": "object",
-                    "title": "Schema for private workload cluster proxy setup",
-                    "properties": {
-                        "http_proxy": {
-                            "description": "base URL of the proxy for HTTP traffic (https://hostname:8080)",
-                            "type": "string"
-                        },
-                        "https_proxy": {
-                            "description": "base URL of the proxy for HTTPS traffic (https://hostname:8080)",
-                            "type": "string"
-                        },
-                        "no_proxy": {
-                            "description": "comma-separated list of IP ranges and hostnames, which should not go through the proxy",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "https_proxy",
-                        "no_proxy"
-                    ]
+                "enabled": {
+                    "description": "indication whether the proxy is enabled",
+                    "type": "boolean"
+                },
+                "http_proxy": {
+                    "description": "base URL of the proxy for HTTP traffic (https://hostname:8080)",
+                    "type": "string"
+                },
+                "https_proxy": {
+                    "description": "base URL of the proxy for HTTPS traffic (https://hostname:8080)",
+                    "type": "string"
+                },
+                "no_proxy": {
+                    "description": "comma-separated list of IP ranges and hostnames, which should not go through the proxy",
+                    "type": "string"
                 }
-            }
+            },
+            "required": [
+                "https_proxy",
+                "no_proxy"
+            ]
         }
     }
 }

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -86,3 +86,9 @@ managementCluster:
 
 # Giant Swarm properties for workload clusters
 isWorkloadCluster: false
+
+cluster:
+  proxy:
+    http_proxy: ""
+    https_proxy: ""
+    no_proxy: ""

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -87,8 +87,8 @@ managementCluster:
 # Giant Swarm properties for workload clusters
 isWorkloadCluster: false
 
-cluster:
-  proxy:
-    http_proxy: ""
-    https_proxy: ""
-    no_proxy: ""
+proxy:
+  enabled: true
+  http_proxy: "https://example.com"
+  https_proxy: "https://example.com"
+  no_proxy: "172.16.0.0/16"

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -88,7 +88,7 @@ managementCluster:
 isWorkloadCluster: false
 
 proxy:
-  enabled: true
-  http_proxy: "https://example.com"
-  https_proxy: "https://example.com"
-  no_proxy: "172.16.0.0/16"
+  enabled: false
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""


### PR DESCRIPTION
When Dex is deployed to a private workload cluster, it needs to have a proxy configured in order to be able to communicate with external identity providers.

The proxy configuration is passed to the application in 3 environment variables: 
- `HTTP_PROXY`: workload cluster proxy base URL
- `HTTPS_PROXY`: workload cluster proxy base URL
- `NO_PROXY`: comma-separated list of IP ranges and/or hostnames, which should not go through the proxy. Dex requires the IP address/range of Kubernetes API service to be included as a value

Values for these environment variables need to match those defined in the workload cluster configuration. Ideally the values defined in the cluster configuration would also be available to the configurations of the apps deployed in the cluster. However, this is not the case at the moment.

This PR introduces a way to specify the content for the required environment variables manually in the user config values as a quick way to make Dex work in a private workload cluster.

The proxy configuration object has the same structure as in the workload cluster user values.

## Checklist

- [x] Update CHANGELOG.md
