### PR TITLE
Added a possibility to configure a custom trusted root CA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a possibility to configure a custom trusted root CA
+
 ## [1.32.2] - 2023-01-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,32 @@ Notes:
 
 As a result, you should see Dex deployed in your workload cluster.
 
+### Ingress, TLS and custom certification authorities
+
+Dex app exposes a web interface, which is accessible over https. Therefore, it creates an ingress, which needs to be configured with a TLS certificate signed by a certification authority, which needs to be trusted by the browsers. 
+The app consists of several components, which also need to be able to communicate with each other internally over https. So the certification authority signing the certificates needs to be trusted by the individual app components as well.
+
+In case a custom certification authority is used, it needs to be exposed to the individual app components and set as trusted, otherwise the components will not be able to communicate with each other and the app may not work as expected.
+Based on the cluster setup, this can be achieved by providing an additional set of values to the app configuration:
+
+1. Add a base64-encoded certificate of the certification authority to the User Values configmap or secret. This option is useful when using custom, self-signed certificates in a cluster:
+
+```yaml
+ingress:
+  tls:
+    letsencrypt: false
+    caPemB64: "base64-encoded CA certificate"
+```
+
+2. Provide a reference to an existing Secret resource, which contyains the custom certification authority. This option is useful for cluster setup, where TLS certificates signed by a custom certification authority are provided by an external service:
+
+```yaml
+trustedRootCA:
+  name: "name-of-the property-in-the-secret"
+  secretName: "name-of-the-custom-ca-secret"
+```
+
+
 ## Update Process
 
 Giant Swarm is currently building the `dex` app from [a fork](https://github.com/giantswarm/dex) of the [original project](https://github.com/dexidp/dex).

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ingress:
     caPemB64: "base64-encoded CA certificate"
 ```
 
-2. Provide a reference to an existing Secret resource, which contyains the custom certification authority. This option is useful for cluster setup, where TLS certificates signed by a custom certification authority are provided by an external service:
+2. Provide a reference to an existing Secret resource, which contains the custom certification authority. This option is useful for cluster setup, where TLS certificates signed by a custom certification authority are provided by an external service:
 
 ```yaml
 ingress:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ ingress:
 2. Provide a reference to an existing Secret resource, which contyains the custom certification authority. This option is useful for cluster setup, where TLS certificates signed by a custom certification authority are provided by an external service:
 
 ```yaml
+ingress:
+  tls:
+    letsencrypt: false
+
 trustedRootCA:
   name: "name-of-the property-in-the-secret"
   secretName: "name-of-the-custom-ca-secret"

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-customer.yaml
@@ -91,6 +91,15 @@ spec:
         configMap:
           name: {{ include "resource.dexk8sauth.name" $resource }}-{{ .id }}
       {{- if not $values.ingress.tls.letsencrypt }}
+      {{- if $values.trustedRootCA }}
+      - name: ca-cert
+        secret:
+          defaultMode: 420
+          items:
+            - key: {{ $values.trustedRootCA.name }}
+              path: ca.crt
+          secretName: {{ $values.trustedRootCA.secretName }}
+      {{- else }}
       - secret:
           defaultMode: 420
           items:
@@ -98,6 +107,7 @@ spec:
             path: ca.crt
           secretName: {{ include "resource.dexk8sauth.name" $resource }}
         name: ca-cert
+      {{- end }}
       {{- end }}
 {{- end }}
 {{- else }}
@@ -185,6 +195,15 @@ spec:
         configMap:
           name: {{ include "resource.dexk8sauth.name" . }}-customer
       {{- if not .Values.ingress.tls.letsencrypt }}
+      {{- if .Values.trustedRootCA }}
+      - name: ca-cert
+        secret:
+          defaultMode: 420
+          items:
+            - key: {{ .Values.trustedRootCA.name }}
+              path: ca.crt
+          secretName: {{ .Values.trustedRootCA.secretName }}
+      {{- else }}
       - secret:
           defaultMode: 420
           items:
@@ -192,6 +211,7 @@ spec:
             path: ca.crt
           secretName: {{ include "resource.dexk8sauth.name" . }}
         name: ca-cert
+      {{- end }}
       {{- end }}
 {{ end }}
 {{ end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-giantswarm.yaml
@@ -83,22 +83,32 @@ spec:
         configMap:
           name: {{ include "resource.dexk8sauth.name" . }}-giantswarm
       {{- if not .Values.ingress.tls.letsencrypt }}
+      {{- if .Values.trustedRootCA }}
+      - name: ca-cert
+        secret:
+          defaultMode: 420
+          items:
+          - key: {{ .Values.trustedRootCA.name }}
+            path: ca.crt
+          secretName: {{ .Values.trustedRootCA.secretName }}
+      {{- else }}
       {{- if ne .Values.ingress.tls.clusterIssuer "" }}
-      - secret:
+      - name: ca-cert
+        secret:
           defaultMode: 420
           items:
           - key: ca.crt
             path: ca.crt
           secretName: {{ include "resource.dex.name" . }}-tls
-        name: ca-cert
       {{- else }}
-      - secret:
+      - name: ca-cert
+        secret:
           defaultMode: 420
           items:
           - key: ca.crt
             path: ca.crt
           secretName: {{ include "resource.dexk8sauth.name" . }}
-        name: ca-cert
+      {{- end }}
       {{- end }}
       {{- end }}
 {{ end }}

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -112,6 +112,21 @@
                 }
             }
         },
+        "trustedRootCA": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "secretName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "secretName"
+            ]
+        },
         "oidc": {
             "type": "object",
             "properties": {

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -28,10 +28,6 @@ ingress:
     crtPemB64: ""
     keyPemB64: ""
 
-trustedRootCA:
-  name: ""
-  secretName: ""
-
 oidc:
   issuerAddress: ""
   expiry:

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -28,6 +28,10 @@ ingress:
     crtPemB64: ""
     keyPemB64: ""
 
+trustedRootCA:
+  name: ""
+  secretName: ""
+
 oidc:
   issuerAddress: ""
   expiry:


### PR DESCRIPTION
Added a new object to Helm values to read and configure a custom certification authority from an existing secret.

It only owrks in case letsencrypt is disabled.

Example usage:

user config values:
```yaml
ingress:
  tls:
    letsencrypt: false

trustedRootCA:
  name: "ca.crt"
  secretName: "installation-ca"
```

## Checklist

- [x] Update CHANGELOG.md
