### PR TITLE
support for external-dns on ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add additional annotations on all `ingress` objects to support DNS record creation via `external-dns`
+
 ## [1.32.3] - 2023-02-22
 
 ### Added

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -15,6 +15,14 @@ metadata:
     {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
+    {{- if .Values.ingress.externalDNS }}
+    {{- if .Values.isWorkloadCluster }}
+    external-dns.alpha.kubernetes.io/hostname: login.{{ .Values.baseDomain }}
+    {{- else if .Values.isManagementCluster }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientAddress }}
+    {{- end }}
+    giantswarm.io/external-dns: managed
+    {{- end }}
 spec:
   ingressClassName: nginx
   tls:

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -14,6 +14,14 @@ metadata:
     {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
+    {{- if .Values.ingress.externalDNS }}
+    {{- if .Values.isWorkloadCluster }}
+    external-dns.alpha.kubernetes.io/hostname: dex.{{ .Values.baseDomain }}
+    {{- else if .Values.isManagementCluster }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.oidc.issuerAddress }}
+    {{- end }}
+    giantswarm.io/external-dns: managed
+    {{- end }}
 spec:
   ingressClassName: nginx
   tls:

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -73,13 +73,16 @@
         "ingress": {
             "type": "object",
             "properties": {
+                "externalDNS": {
+                    "type": "boolean"
+                },
                 "tls": {
                     "type": "object",
                     "properties": {
                         "caPemB64": {
                             "type": "string"
                         },
-			"clusterIssuer": {
+                        "clusterIssuer": {
                             "type": "string"
                         },
                         "crtPemB64": {
@@ -105,7 +108,10 @@
             "type": "string"
         },
         "managementCluster": {
-            "type": ["object", "string"],
+            "type": [
+                "object",
+                "string"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -143,7 +149,10 @@
                             "type": "string"
                         },
                         "connectors": {
-                            "type": ["array", "null"],
+                            "type": [
+                                "array",
+                                "null"
+                            ],
                             "items": {
                                 "type": "object",
                                 "properties": {
@@ -202,7 +211,10 @@
                             }
                         },
                         "connectors": {
-                            "type": ["array", "null"],
+                            "type": [
+                                "array",
+                                "null"
+                            ],
                             "items": {
                                 "type": "object",
                                 "properties": {

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -21,6 +21,7 @@ extraVolumeMounts: []
 logoURI: https://s.giantswarm.io/brand/1/logo.svg
 
 ingress:
+  externalDNS: false
   tls:
     letsencrypt: true
     clusterIssuer: ""


### PR DESCRIPTION
to support dns-record creation via external-dns, two additional annotations are needed to make external-dns work on dex created ingress objects.

towards: https://github.com/giantswarm/roadmap/issues/1037
related config repo change: https://github.com/giantswarm/config/pull/1607

## Checklist

- [x] Update CHANGELOG.md
