### PR TITLE
Added support for custom static clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for custom static clients
+
 ## [1.36.0] - 2023-07-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support for custom static clients
+### Added
+
+- Add support for custom static clients
 
 ## [1.36.0] - 2023-07-11
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,34 @@ cluster:
     noProxy: "kubernetes-api-ip-range" # comma-separated list of hostnames and IP ranges, whose traffic should not go through the proxy. # Kubernetes API IP range needs to be defined here in order for Dex to work correctly
 ```
 
+### Static clients
+
+In addition to a few pre-defined static clients Dex app supports the possibility to define custom static clients as well.
+They need to be defined as an array of object in a specific property of the configuration yaml file called `extraStaticClients`.
+The structure of each custom static client object is exactly the same as in upstream Dex:
+
+```yaml
+extraStaticClients:
+- id: "client-id"
+  secret: "client-secret"
+  trustedPeers:
+  - "https://example.com"
+  public: true
+  name: "client-name-1"
+  logoURL: "https://example.com/logo"
+- idEnv: "CLIENT_ID"
+  secretEnv: "CLIENT_SECRET"
+  redirectURIs:
+  - "https://example.com/redirect"
+  name: "client-name-2"
+```
+
+**Notes:**
+
+- `id` and `idEnv` properties are mutually exclusive
+- `secret` and `secretEnv` properties are mutually exclusive
+- `name`, `id` or `idEnv` and `secret` or `secretEnv` are required properties
+
 ## Update Process
 
 Giant Swarm is currently building the `dex` app from [a fork](https://github.com/giantswarm/dex) of the [original project](https://github.com/dexidp/dex).

--- a/README.md
+++ b/README.md
@@ -208,7 +208,10 @@ extraStaticClients:
 
 - `id` and `idEnv` properties are mutually exclusive
 - `secret` and `secretEnv` properties are mutually exclusive
-- `name`, `id` or `idEnv` and `secret` or `secretEnv` are required properties
+- Required properties:
+  - `name` 
+  - `id` or `idEnv` 
+  - `secret` or `secretEnv`
 
 ## Update Process
 

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -100,6 +100,9 @@ stringData:
       - {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
       {{- end }}
     {{- end }}
+    {{- if .Values.oidc.extraStaticClients }}
+    {{- .Values.oidc.extraStaticClients | toYaml | nindent 4 -}}
+    {{- end }}
     connectors:
     {{- if .Values.oidc.giantswarm.connectorConfig.clientID }}
     - type: github

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -244,6 +244,72 @@
                 "issuerAddress": {
                     "type": "string"
                 },
+                "extraStaticClients": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "idEnv": {
+                                "type": "string"
+                            },
+                            "secret": {
+                                "type": "string"
+                            },
+                            "secretEnv": {
+                                "type": "string"
+                            },
+                            "redirectURIs": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "trustedPeers": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "public": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "logoURL": {
+                                "type": "string"
+                            }
+                        },
+                        "allOf": [{
+                            "oneOf": [{
+                                "required": [
+                                    "id"
+                                ]
+                            }, {
+                                "required": [
+                                    "idEnv"
+                                ]
+                            }]
+                        }, {
+                            "oneOf": [{
+                                "required": [
+                                    "secret"
+                                ]
+                            }, {
+                                "required": [
+                                    "secretEnv"
+                                ]
+                            }]
+                        }, {
+                            "required": [
+                                "name"
+                            ]
+                        }]
+                    }
+                },
                 "staticClients": {
                     "type": "object",
                     "properties": {

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -51,6 +51,7 @@ oidc:
     dexK8SAuthenticator:
       clientAddress: ""
       clientSecret: "default-client-dex-authenticator-secret"
+  extraStaticClients: []
   # Giant Swarm OIDC values to run DEX in the management clusters
   giantswarm:
     connectorConfig:


### PR DESCRIPTION
Added a possibility to configure custom static clients in the Dex app values.

The custom static clients need to be specified as an array of objects in a dedicated field called `extraStaticClients`.

The static client object has the same format as in upstream Dex. It does not seem to be documented though, so the structure was also added/documented in the README file of this app.

## Checklist

- [x] Update CHANGELOG.md
