### PR TITLE
Reorder connectors in login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reorder connectors in login screen.
 - Update app-test-suite dependencies.
 
 ## [1.38.0] - 2023-08-08

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -30,9 +30,21 @@
     const connectorFilter = new URL(document.location).searchParams.get(
       'connector_filter'
     );
-    const filteredConnectors = connectors.filter((c) =>
+    const filteredConnectors = connectorFilter === null ? connectors : connectors.filter((c) =>
       c.id.startsWith(connectorFilter)
     );
+    filteredConnectors.sort((a, b) => {
+      const giantSwarmPrefix = 'giantswarm';
+      // if id starts with giantswarm, put it last
+      if (a.id.startsWith(giantSwarmPrefix) && !b.id.startsWith(giantSwarmPrefix)) {
+        return 1;
+      }
+      if (!a.id.startsWith(giantSwarmPrefix) && b.id.startsWith(giantSwarmPrefix)) {
+        return -1;
+      }
+      // otherwise sort by id
+      return a.id.localeCompare(b.id);
+    });
     const connectorsContainer = document.querySelector('#connectors');
 
     if (connectorFilter && filteredConnectors.length === 0) {


### PR DESCRIPTION
This PR reorders the connectors in the login screen to always show connectors whose id starts with `giantswarm` at the bottom and orders the rest alphabetically.

Towards https://github.com/giantswarm/giantswarm/issues/25519

## Checklist

- [x] Update CHANGELOG.md
