### PR TITLE
Improved incorrect connector error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a note with additional explanations to Dex error page in case the error is that the authenticated user is not present in the required orgs or teams.  
+
 ### Changed
 
 - Reorder connectors in login screen.

--- a/web/templates/error.html
+++ b/web/templates/error.html
@@ -12,6 +12,7 @@
     'connector_id'
   );
   const errorContainerEl = document.querySelector('#error');
+  const connectorErrorPattern = /Failed to authenticate: ([^ :]+): user "([^ ]+)" not in required orgs or teams/;
 
   if (
     connectorID &&
@@ -32,12 +33,22 @@
   } else {
     const errorTypeEl = document.createElement('h2');
     errorTypeEl.classList.add('theme-heading');
-    errorTypeEl.textContent = {{ .ErrType }};
 
     const errorMsgEl = document.createElement('p');
     errorMsgEl.textContent = errorMsg;
 
-    errorContainerEl.append(errorTypeEl, errorMsgEl);
+    if (connectorErrorPattern.test(errorMsg)) {
+      const errorNoteEl = document.createElement('p');
+      errorNoteEl.classList.add('theme-note');
+      errorNoteEl.textContent = '* Please ensure that you log in with the correct connector. ' +
+              'If you log in via kubectl gs, please note that the "--cluster-admin" flag only works for Giantswarm staff authentication.';
+
+      errorMsgEl.textContent += "*";
+
+      errorContainerEl.append(errorTypeEl, errorMsgEl, errorNoteEl);
+    } else {
+      errorContainerEl.append(errorTypeEl, errorMsgEl);
+    }
   }
 </script>
 

--- a/web/themes/dark/styles.css
+++ b/web/themes/dark/styles.css
@@ -35,6 +35,11 @@
   color: #c8d1d9;
 }
 
+.theme-note {
+  font-size: 12px;
+  color: #c8d1d9;
+}
+
 .theme-panel {
   background-color: #161b22;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);

--- a/web/themes/light/styles.css
+++ b/web/themes/light/styles.css
@@ -35,6 +35,11 @@
   margin-top: 0;
 }
 
+.theme-note {
+  font-size: 12px;
+  color: #999;
+}
+
 .theme-panel {
   background-color: #fff;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Added a note to Dex error page indicating that the authenticted user is not included in the required group(s).

The note explains that a correct connector needs to be used and and that the --cluster-admin flag in kubectl gs it meant to be used by GS staff in case the user logged in via kubectl gs.

![Screenshot 2023-08-11 at 15 48 38](https://github.com/giantswarm/dex-app/assets/2923801/ef318a22-467e-4f03-97b6-5fc609e96f18)

Other error pages/messages remain uinchanged.

Note: In case of an authentication failure some connectors (e.g. Azure AD) terminate the flow before they redirect back to Dex and present their own error page/message. These error messages cannot be modified.

## Checklist

- [x] Update CHANGELOG.md
