### PR TITLE
enable external tls secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `oidc.staticClients.dexK8sAuthenticator.enableDeployment` option to disable the deployment of dex-k8s-authenticator.
+- Added `deployDexK8SAuthenticator` option to disable the deployment of dex-k8s-authenticator.
 - Added `ingress.tls.externalSecret.enabled` option to disable tls secret creation and allow usage of an external secret.
 
 ## [1.41.0] - 2023-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `oidc.staticClients.dexK8sAuthenticator.enableDeployment` option to disable the deployment of dex-k8s-authenticator.
+- Added `ingress.tls.externalSecret.enabled` option to disable tls secret creation and allow usage of an external secret.
+
 ## [1.41.0] - 2023-10-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,6 +168,31 @@ trustedRootCA:
   secretName: "name-of-the-custom-ca-secret"
 ```
 
+3. When disabling `letsencrypt`, a secret called `dex-tls` will be created and propagated with the b64-encoded values provided by the user.
+Alternatively, the user can manage the creation of this secret by themselves and enable its usage like so:
+
+```yaml
+ingress:
+  tls:
+    letsencrypt: false
+    externalSecret:
+      enabled: true
+```
+
+The following secret then needs to be applied to the namespace `dex` is running in:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: dex-tls
+data:
+  ca.crt: ...
+  tls.crt: ...
+  tls.key: ...
+```
+
 ### Proxy configuration
 
 In case the traffic to Dex needs to go through a proxy (for example when the app is installed in a private cluster), the individual components of the app need to be set up to use the proxy.

--- a/helm/dex-app/Chart.yaml
+++ b/helm/dex-app/Chart.yaml
@@ -28,4 +28,4 @@ annotations:
   application.giantswarm.io/team: bigmac
   application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/dex-app/v[[ .Version ]]/README.md
   application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/dex-app/v[[ .Version ]]/helm/dex-app/values.schema.json
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: test-disable-dex-tls-secret

--- a/helm/dex-app/Chart.yaml
+++ b/helm/dex-app/Chart.yaml
@@ -28,4 +28,4 @@ annotations:
   application.giantswarm.io/team: bigmac
   application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/dex-app/v[[ .Version ]]/README.md
   application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/dex-app/v[[ .Version ]]/helm/dex-app/values.schema.json
-  config.giantswarm.io/version: test-disable-dex-tls-secret
+  config.giantswarm.io/version: 1.x.x

--- a/helm/dex-app/templates/dex-k8s-authenticator/certs-secret.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/certs-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 {{- if not .Values.ingress.tls.letsencrypt }}
 {{- if not .Values.ingress.tls.externalSecret.enabled }}
 apiVersion: v1

--- a/helm/dex-app/templates/dex-k8s-authenticator/certs-secret.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/certs-secret.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 {{- if not .Values.ingress.tls.letsencrypt }}
+{{- if not .Values.ingress.tls.externalSecret.enabled }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -10,4 +12,6 @@ data:
   ca.crt: {{ .Values.ingress.tls.caPemB64 | quote }}
   tls.crt: {{ .Values.ingress.tls.crtPemB64 | quote }}
   tls.key: {{ .Values.ingress.tls.keyPemB64 | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/clusterrole.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -13,3 +14,4 @@ rules:
   - {{ include  "resource.dexk8sauth.psp.name" . }}
   verbs:
   - use
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/clusterrole.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/dex-app/templates/dex-k8s-authenticator/clusterrolebinding.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/dex-app/templates/dex-k8s-authenticator/clusterrolebinding.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "resource.dexk8sauth.name" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 {{ if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
 {{ $values := .Values }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 {{ if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
 {{ $values := .Values }}
@@ -114,3 +115,4 @@ data:
     {{- end }}
 {{ end }}
 {{ end }}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-customer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 {{ if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
 {{ $values := .Values }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/deployment-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/deployment-customer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 {{ if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
 {{ $values := .Values }}
@@ -231,3 +232,4 @@ spec:
       {{- end }}
 {{ end }}
 {{ end }}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 {{ if or (eq (include "has-giantswarm-connector" .) "true") .Values.oidc.customer.enabled }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 {{ if or (eq (include "has-giantswarm-connector" .) "true") .Values.oidc.customer.enabled }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
@@ -93,3 +94,4 @@ spec:
     host: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientAddress }}
   {{- end }}
 {{ end }}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/np.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/np.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:

--- a/helm/dex-app/templates/dex-k8s-authenticator/np.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/np.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -17,3 +18,4 @@ spec:
       protocol: TCP
   egress:
   - {}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/psp.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -29,4 +30,5 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}
 {{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/psp.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/helm/dex-app/templates/dex-k8s-authenticator/service-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/service-customer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 {{ if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
 {{ $values := .Values }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/service-customer.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/service-customer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 {{ if .Values.oidc.customer.enabled }}
 {{- if .Values.oidc.customer.connectors -}}
 {{ $values := .Values }}
@@ -39,3 +40,4 @@ spec:
     {{- include "dexk8sauth.customer.labels.selector" . | nindent 4 }}
 {{ end }}
 {{ end }}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/serviceaccount.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/serviceaccount.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     {{- include "dexk8sauth.labels.common" . | nindent 4 }}
   name: {{ include "resource.dexk8sauth.name" . }}
+{{- end }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/serviceaccount.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.oidc.staticClients.dexK8SAuthenticator.enableDeployment }}
+{{- if .Values.deployDexK8SAuthenticator }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/dex-app/templates/dex/certs-secret.yaml
+++ b/helm/dex-app/templates/dex/certs-secret.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.ingress.tls.letsencrypt }}
+{{- if not .Values.ingress.tls.externalSecret.enabled }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -10,4 +11,5 @@ data:
   ca.crt: {{ .Values.ingress.tls.caPemB64 | quote }}
   tls.crt: {{ .Values.ingress.tls.crtPemB64 | quote }}
   tls.key: {{ .Values.ingress.tls.keyPemB64 | quote }}
+{{- end }}
 {{- end }}

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -56,6 +56,9 @@
                 }
             }
         },
+        "deployDexK8SAuthenticator": {
+            "type": "boolean"
+        },
         "dex": {
             "type": "object",
             "properties": {
@@ -345,9 +348,6 @@
                                 },
                                 "clientSecret": {
                                     "type": "string"
-                                },
-                                "enableDeployment": {
-                                    "type": "boolean"
                                 }
                             }
                         },

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -109,6 +109,14 @@
                         },
                         "letsencrypt": {
                             "type": "boolean"
+                        },
+                        "externalSecret": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 }
@@ -337,6 +345,9 @@
                                 },
                                 "clientSecret": {
                                     "type": "string"
+                                },
+                                "enableDeployment": {
+                                    "type": "boolean"
                                 }
                             }
                         },

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -29,7 +29,7 @@ ingress:
     caPemB64: ""
     crtPemB64: ""
     keyPemB64: ""
-    externalSecret: 
+    externalSecret:
       enabled: false
 
 oidc:

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -54,7 +54,6 @@ oidc:
     dexK8SAuthenticator:
       clientAddress: ""
       clientSecret: "default-client-dex-authenticator-secret"
-      enableDeployment: true
   extraStaticClients: []
   # Giant Swarm OIDC values to run DEX in the management clusters
   giantswarm:
@@ -98,6 +97,10 @@ managementCluster:
 
 # Giant Swarm properties for workload clusters
 isWorkloadCluster: false
+
+# Enable the deployment of the dex k8s authenticator together with dex
+# Please note that this app is deprecated and will be removed in the future
+deployDexK8SAuthenticator: true
 
 cluster:
   proxy:

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -29,6 +29,8 @@ ingress:
     caPemB64: ""
     crtPemB64: ""
     keyPemB64: ""
+    externalSecret: 
+      enabled: false
 
 oidc:
   issuerAddress: ""
@@ -52,6 +54,7 @@ oidc:
     dexK8SAuthenticator:
       clientAddress: ""
       clientSecret: "default-client-dex-authenticator-secret"
+      enableDeployment: true
   extraStaticClients: []
   # Giant Swarm OIDC values to run DEX in the management clusters
   giantswarm:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2933 https://github.com/giantswarm/roadmap/issues/1228

This PR adds a boolean flag to allow disabling the creation of the tls secret in the chart so that users can provide it themselves.
It also allows disabling the deployment of dex-k8s-authenticator since we want to remove it eventually. The reason it's included here is that this change would otherwise force the user to also manage the tls secret for the authenticator, even if they are not using it.

## Checklist

- [ ] Update CHANGELOG.md
