### PR TITLE
Extra static clients as trusted peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adding new properties to configure trusted peers in pre-defined static clients 
+
 ## [1.42.0] - 2023-11-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -234,9 +234,58 @@ extraStaticClients:
 - `id` and `idEnv` properties are mutually exclusive
 - `secret` and `secretEnv` properties are mutually exclusive
 - Required properties:
-  - `name` 
-  - `id` or `idEnv` 
+  - `name`
+  - `id` or `idEnv`
   - `secret` or `secretEnv`
+
+Extra static clients can also be configured as trusted peers of the pre-defined static clients. 
+It can be achieved by taking one of the following 2 approaches:
+
+**1. Add the extra static client id to the list of `trustedPeers` in the pre-defined static client:**
+
+```yaml
+staticClients:
+  dexK8SAuthenticator:
+    clientAddress: "dex.installation.basedomain.io"
+    clientSecret: "default-client-dex-authenticator-secret"
+    trustedPeers:
+    - "client-id" 
+extraStaticClients:
+- id: "client-id"
+  name: "client-name-1"
+  secret: "client-secret"
+```
+
+**2. Add the pre-defined static client id to the `trustedPeerOf` list in the extra static client:**
+
+```yaml
+staticClients:
+  dexK8SAuthenticator:
+    clientAddress: "dex.installation.basedomain.io"
+    clientSecret: "default-client-dex-authenticator-secret" 
+extraStaticClients:
+- id: "client-id"
+  name: "client-name-1"
+  secret: "client-secret"
+  trustedPeerOf:
+  - "dex-k8s-authenticator" # this needs to be the client ID
+```
+
+Both approaches will produce the same configuration:
+
+```yaml
+staticClients:
+- id: dex-k8s-authenticator
+  name: dex-k8s-authenticator
+  secret: default-client-dex-authenticator-secret
+  trustedPeers:
+  - client-id
+- id: client-id
+  name: client-name-1
+  secret: client-secret
+  public: true
+```
+Duplicities are prevented in case an ID of any additional trusted peer equals an automatically pre-populated trusted peer ID.
 
 ## Update Process
 

--- a/README.md
+++ b/README.md
@@ -238,10 +238,9 @@ extraStaticClients:
   - `id` or `idEnv`
   - `secret` or `secretEnv`
 
-Extra static clients can also be configured as trusted peers of the pre-defined static clients. 
-It can be achieved by taking one of the following 2 approaches:
+Extra static clients can also be configured as trusted peers of the pre-defined static clients:
 
-**1. Add the extra static client id to the list of `trustedPeers` in the pre-defined static client:**
+**Add the extra static client id to the list of `trustedPeers` in the pre-defined static client:**
 
 ```yaml
 staticClients:
@@ -256,22 +255,7 @@ extraStaticClients:
   secret: "client-secret"
 ```
 
-**2. Add the pre-defined static client id to the `trustedPeerOf` list in the extra static client:**
-
-```yaml
-staticClients:
-  dexK8SAuthenticator:
-    clientAddress: "dex.installation.basedomain.io"
-    clientSecret: "default-client-dex-authenticator-secret" 
-extraStaticClients:
-- id: "client-id"
-  name: "client-name-1"
-  secret: "client-secret"
-  trustedPeerOf:
-  - "dex-k8s-authenticator" # this needs to be the client ID
-```
-
-Both approaches will produce the same configuration:
+It will produce the same configuration:
 
 ```yaml
 staticClients:

--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -101,26 +101,26 @@ Abstract the knowledge to know if its installed on a workload cluster or not
 Gather and print trusted peers of a static client from various sources
 */}}
 {{- define "trusted-peers" -}}
-  {{- $extraStaticClients := fromYamlArray "[]" -}}
-  {{- $staticTrustedPeers := fromYamlArray "[]" -}}
+  {{- $trustedPeers := fromYamlArray "[]" -}}
   {{- if .staticTrustedPeers -}}
-    {{- $staticTrustedPeers = compact .staticTrustedPeers -}}
+    {{- $trustedPeers = compact .staticTrustedPeers -}}
+  {{- end -}}
+  {{- if .trustedPeers -}}
+    {{- $trustedPeers = concat $trustedPeers (compact .trustedPeers) -}}
   {{- end -}}
   {{- if .extraStaticClients -}}
     {{- $refId := .refId -}}
     {{- range .extraStaticClients }}
       {{- if has $refId .trustedPeerOf -}}
-        {{- $extraStaticClients = append $extraStaticClients .id -}}
+        {{- $trustedPeers = append $trustedPeers .id -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
-  {{- if or $staticTrustedPeers $extraStaticClients }}
+  {{- $trustedPeers = uniq $trustedPeers -}}
+  {{- if $trustedPeers }}
     {{- print "trustedPeers:" | nindent 6 -}}
-    {{- if $staticTrustedPeers -}}
-      {{- $staticTrustedPeers | toYaml | nindent 6 -}}
-    {{- end -}}
-    {{- if $extraStaticClients -}}
-      {{- $extraStaticClients | toYaml | nindent 6 -}}
+    {{- if $trustedPeers -}}
+      {{- $trustedPeers | toYaml | nindent 6 -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -108,14 +108,6 @@ Gather and print trusted peers of a static client from various sources
   {{- if .trustedPeers -}}
     {{- $trustedPeers = concat $trustedPeers (compact .trustedPeers) -}}
   {{- end -}}
-  {{- if .extraStaticClients -}}
-    {{- $refId := .refId -}}
-    {{- range .extraStaticClients }}
-      {{- if has $refId .trustedPeerOf -}}
-        {{- $trustedPeers = append $trustedPeers .id -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
   {{- $trustedPeers = uniq $trustedPeers -}}
   {{- if $trustedPeers }}
     {{- print "trustedPeers:" | nindent 6 -}}

--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -101,18 +101,13 @@ Abstract the knowledge to know if its installed on a workload cluster or not
 Gather and print trusted peers of a static client from various sources
 */}}
 {{- define "trusted-peers" -}}
-  {{- $trustedPeers := fromYamlArray "[]" -}}
-  {{- if .staticTrustedPeers -}}
-    {{- $trustedPeers = compact .staticTrustedPeers -}}
-  {{- end -}}
-  {{- if .trustedPeers -}}
-    {{- $trustedPeers = concat $trustedPeers (compact .trustedPeers) -}}
-  {{- end -}}
-  {{- $trustedPeers = uniq $trustedPeers -}}
-  {{- if $trustedPeers }}
-    {{- print "trustedPeers:" | nindent 6 -}}
-    {{- if $trustedPeers -}}
-      {{- $trustedPeers | toYaml | nindent 6 -}}
+  {{- if . }}
+    {{- $trustedPeers := uniq ( compact . ) -}}
+    {{- if $trustedPeers }}
+      {{- print "trustedPeers:" | nindent 6 -}}
+      {{- if $trustedPeers -}}
+        {{- $trustedPeers | toYaml | nindent 6 -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -96,3 +96,44 @@ Abstract the knowledge to know if its installed on a workload cluster or not
   {{- printf "false" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Gather and print trusted peers of a static client from various sources
+*/}}
+{{- define "trusted-peers" -}}
+  {{- $extraStaticClients := fromYamlArray "[]" -}}
+  {{- $staticTrustedPeers := fromYamlArray "[]" -}}
+  {{- if .staticTrustedPeers -}}
+    {{- $staticTrustedPeers = compact .staticTrustedPeers -}}
+  {{- end -}}
+  {{- if .extraStaticClients -}}
+    {{- $refId := .refId -}}
+    {{- range .extraStaticClients }}
+      {{- if has $refId .trustedPeerOf -}}
+        {{- $extraStaticClients = append $extraStaticClients .id -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if or $staticTrustedPeers $extraStaticClients }}
+    {{- print "trustedPeers:" | nindent 6 -}}
+    {{- if $staticTrustedPeers -}}
+      {{- $staticTrustedPeers | toYaml | nindent 6 -}}
+    {{- end -}}
+    {{- if $extraStaticClients -}}
+      {{- $extraStaticClients | toYaml | nindent 6 -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Clean up and print extra static clients
+*/}}
+{{- define "print-clean-extra-static-clients" -}}
+  {{- if . }}
+    {{- $extraStaticClients := list nil -}}
+    {{- range . -}}
+      {{- $extraStaticClients = append $extraStaticClients (omit . "trustedPeerOf") -}}
+    {{- end -}}
+    {{- compact $extraStaticClients | toYaml | nindent 4 -}}
+  {{- end -}}
+{{- end -}}

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -48,7 +48,7 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.gitopsui.redirectURI }}
       - http://localhost:9001/oauth2/callback
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gitopsui.trustedPeers ) }}
+      {{- include "trusted-peers" .Values.oidc.staticClients.gitopsui.trustedPeers }}
     {{- end }}
     {{- if .Values.oidc.staticClients.grafana.clientID }}
     - id: {{ .Values.oidc.staticClients.grafana.clientID }}
@@ -56,13 +56,13 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.grafana.redirectURI }}
       name: grafana
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.grafana.trustedPeers ) }}
+      {{- include "trusted-peers" .Values.oidc.staticClients.grafana.trustedPeers }}
     {{- end }}
     {{- if .Values.oidc.staticClients.gsCLIAuth.clientID }}
     - id: {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
       public: true
       name: gscliauth
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gsCLIAuth.trustedPeers ) }}
+      {{- include "trusted-peers" .Values.oidc.staticClients.gsCLIAuth.trustedPeers }}
     {{- end }}
     {{- if .Values.oidc.staticClients.happa.clientID }}
     - id: {{ .Values.oidc.staticClients.happa.clientID }}
@@ -71,7 +71,7 @@ stringData:
       - {{ .Values.oidc.staticClients.happa.redirectURI }}
       - http://localhost:7000
       name: happa
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.happa.trustedPeers ) }}
+      {{- include "trusted-peers" .Values.oidc.staticClients.happa.trustedPeers }}
     {{- end }}
     {{- if .Values.isManagementCluster }}
     - id: dex-k8s-authenticator
@@ -84,7 +84,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "staticTrustedPeers" (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
+      {{- include "trusted-peers" ( concat (.Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers | default list ) (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     - id: dex-k8s-authenticator
@@ -95,7 +95,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
+      {{- include "trusted-peers" ( concat (.Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers | default list ) (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- include "print-clean-extra-static-clients" .Values.oidc.extraStaticClients }}
     connectors:

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -48,6 +48,7 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.gitopsui.redirectURI }}
       - http://localhost:9001/oauth2/callback
+      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gitopsui.clientID ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.grafana.clientID }}
     - id: {{ .Values.oidc.staticClients.grafana.clientID }}
@@ -55,11 +56,13 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.grafana.redirectURI }}
       name: grafana
+      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.grafana.clientID ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.gsCLIAuth.clientID }}
     - id: {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
       public: true
       name: gscliauth
+      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gsCLIAuth.clientID ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.happa.clientID }}
     - id: {{ .Values.oidc.staticClients.happa.clientID }}
@@ -68,6 +71,7 @@ stringData:
       - {{ .Values.oidc.staticClients.happa.redirectURI }}
       - http://localhost:7000
       name: happa
+      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.happa.clientID ) }}
     {{- end }}
     {{- if .Values.isManagementCluster }}
     - id: dex-k8s-authenticator
@@ -80,11 +84,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- if (or .Values.oidc.staticClients.gsCLIAuth.clientID .Values.oidc.staticClients.happa.clientID) }}
-      trustedPeers:
-      - {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
-      - {{ .Values.oidc.staticClients.happa.clientID }}
-      {{- end }}
+      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     - id: dex-k8s-authenticator
@@ -95,14 +95,9 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- if .Values.oidc.staticClients.gsCLIAuth.clientID }}
-      trustedPeers:
-      - {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
-      {{- end }}
+      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
-    {{- if .Values.oidc.extraStaticClients }}
-    {{- .Values.oidc.extraStaticClients | toYaml | nindent 4 -}}
-    {{- end }}
+    {{- include "print-clean-extra-static-clients" .Values.oidc.extraStaticClients -}}
     connectors:
     {{- if .Values.oidc.giantswarm.connectorConfig.clientID }}
     - type: github

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -97,7 +97,7 @@ stringData:
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
       {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
-    {{- include "print-clean-extra-static-clients" .Values.oidc.extraStaticClients -}}
+    {{- include "print-clean-extra-static-clients" .Values.oidc.extraStaticClients }}
     connectors:
     {{- if .Values.oidc.giantswarm.connectorConfig.clientID }}
     - type: github

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -48,7 +48,7 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.gitopsui.redirectURI }}
       - http://localhost:9001/oauth2/callback
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gitopsui.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gitopsui.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gitopsui.trustedPeers ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.grafana.clientID }}
     - id: {{ .Values.oidc.staticClients.grafana.clientID }}
@@ -56,13 +56,13 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.grafana.redirectURI }}
       name: grafana
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.grafana.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.grafana.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.grafana.trustedPeers ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.gsCLIAuth.clientID }}
     - id: {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
       public: true
       name: gscliauth
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gsCLIAuth.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gsCLIAuth.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gsCLIAuth.trustedPeers ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.happa.clientID }}
     - id: {{ .Values.oidc.staticClients.happa.clientID }}
@@ -71,7 +71,7 @@ stringData:
       - {{ .Values.oidc.staticClients.happa.redirectURI }}
       - http://localhost:7000
       name: happa
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.happa.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.happa.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.happa.trustedPeers ) }}
     {{- end }}
     {{- if .Values.isManagementCluster }}
     - id: dex-k8s-authenticator
@@ -84,7 +84,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "staticTrustedPeers" (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     - id: dex-k8s-authenticator
@@ -95,7 +95,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- include "print-clean-extra-static-clients" .Values.oidc.extraStaticClients }}
     connectors:

--- a/helm/dex-app/templates/dex/secret.yaml
+++ b/helm/dex-app/templates/dex/secret.yaml
@@ -48,7 +48,7 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.gitopsui.redirectURI }}
       - http://localhost:9001/oauth2/callback
-      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gitopsui.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gitopsui.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gitopsui.clientID ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.grafana.clientID }}
     - id: {{ .Values.oidc.staticClients.grafana.clientID }}
@@ -56,13 +56,13 @@ stringData:
       redirectURIs:
       - {{ .Values.oidc.staticClients.grafana.redirectURI }}
       name: grafana
-      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.grafana.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.grafana.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.grafana.clientID ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.gsCLIAuth.clientID }}
     - id: {{ .Values.oidc.staticClients.gsCLIAuth.clientID }}
       public: true
       name: gscliauth
-      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gsCLIAuth.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.gsCLIAuth.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.gsCLIAuth.clientID ) }}
     {{- end }}
     {{- if .Values.oidc.staticClients.happa.clientID }}
     - id: {{ .Values.oidc.staticClients.happa.clientID }}
@@ -71,7 +71,7 @@ stringData:
       - {{ .Values.oidc.staticClients.happa.redirectURI }}
       - http://localhost:7000
       name: happa
-      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.happa.clientID ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.happa.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" .Values.oidc.staticClients.happa.clientID ) }}
     {{- end }}
     {{- if .Values.isManagementCluster }}
     - id: dex-k8s-authenticator
@@ -84,7 +84,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.happa.clientID .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     - id: dex-k8s-authenticator
@@ -95,7 +95,7 @@ stringData:
       {{- end }}
       name: dex-k8s-authenticator
       secret: {{ .Values.oidc.staticClients.dexK8SAuthenticator.clientSecret }}
-      {{- include "trusted-peers" (dict "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
+      {{- include "trusted-peers" (dict "trustedPeers" .Values.oidc.staticClients.dexK8SAuthenticator.trustedPeers "extraStaticClients" .Values.oidc.extraStaticClients "refId" "dex-k8s-authenticator" "staticTrustedPeers" (list .Values.oidc.staticClients.gsCLIAuth.clientID) ) }}
     {{- end }}
     {{- include "print-clean-extra-static-clients" .Values.oidc.extraStaticClients }}
     connectors:

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -354,6 +354,12 @@
                                 },
                                 "clientSecret": {
                                     "type": "string"
+                                },
+                                "trustedPeers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         },
@@ -368,6 +374,12 @@
                                 },
                                 "redirectURI": {
                                     "type": "string"
+                                },
+                                "trustedPeers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         },
@@ -379,6 +391,12 @@
                                 },
                                 "redirectURI": {
                                     "type": "string"
+                                },
+                                "trustedPeers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         },
@@ -390,6 +408,12 @@
                                 },
                                 "clientID": {
                                     "type": "string"
+                                },
+                                "trustedPeers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         },
@@ -401,6 +425,12 @@
                                 },
                                 "redirectURI": {
                                     "type": "string"
+                                },
+                                "trustedPeers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -308,6 +308,12 @@
                             },
                             "logoURL": {
                                 "type": "string"
+                            },
+                            "trustedPeerOf": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         },
                         "allOf": [{

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -308,12 +308,6 @@
                             },
                             "logoURL": {
                                 "type": "string"
-                            },
-                            "trustedPeerOf": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
                             }
                         },
                         "allOf": [{


### PR DESCRIPTION
Added a possibility to configure extra static clients as trusted peers of permanent static clients.

### The problem

Trusted peers in the permanent static clients are hardcoded. 
Right now there is no way to define additional trusted peers for the permanent static client.

```yaml
# values.yaml

oidc:
  staticClients:
    dex-k8s-authenticator:
      clientAddress: "https://dex.installation.basedomain.io"
      clientSecret: "default-client-dex-authenticator-secret" 
  extraStaticClients:
  # We want the following client to be listed as a trusted peer of `dex-k8s-authenticator`
  - id: extra-static-client-1-id 
    secret: client-secret
    public: true
```

### Suggested solutions:

**Define additional trusted peers in the permanent static clients**

Add a new optional `trustedPeers` property to each permanent static client. If set, the property would contain a list of static client IDs, which are considered trusted peers of the static client in question. In case the property value contains IDs, which are added automatically, the duplicities are removed.

```yaml
#values.yaml

oidc:
  staticClients:
    dex-k8s-authenticator:
      clientAddress: "https://dex.installation.basedomain.io"
      clientSecret: "default-client-dex-authenticator-secret" 
      trustedPeers:
      - extra-static-client-1-id 
  extraStaticClients:
  - id: extra-static-client-1-id 
    secret: client-secret
    public: true
```

It will produce the following configuration in the `dex` secret:

```yaml
# ...
stringData:
  config.yaml: |-
    ...
    staticClients:
    - id: dex-k8s-authenticator
      name: dex-k8s-authenticator
      secret: default-client-dex-authenticator-secret
      trustedPeers:
      - extra-static-client-1-id
    - id: extra-static-client-1-id
      name: extra-static-client-1
      secret: client-secret
      public: true
    ...
```

This PR also introduces filtering and validation in case merging static clients from multiple sources produces duplicate entries or an empty list.

## Checklist

- [x] Update CHANGELOG.md
