### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,15 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.34.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
     jobs:
-      - architect/push-to-docker:
+      - architect/push-to-registries:
           context: architect
-          name: push-dex-app-to-quay
-          image: 'quay.io/giantswarm/dex-app'
-          username_envar: 'QUAY_USERNAME'
-          password_envar: 'QUAY_PASSWORD'
+          name: push-to-registries
           filters:
             # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: architect
-          name: push-dex-app-to-docker
-          image: 'docker.io/giantswarm/dex-app'
-          username_envar: 'DOCKER_USERNAME'
-          password_envar: 'DOCKER_PASSWORD'
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: architect
-          name: push-dex-app-to-aliyun
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/dex-app"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          # Needed to trigger job also on git tag.
-          filters:
-            branches:
-              only: main
             tags:
               only: /^v.*/
 
@@ -50,8 +23,7 @@ workflows:
           persist_chart_archive: true
           push_to_oci_registry: true
           requires:
-            - push-dex-app-to-quay
-            - push-dex-app-to-docker
+            - push-to-registries
           filters:
             # Trigger the job also on git tag.
             tags:
@@ -109,9 +81,7 @@ workflows:
           executor: "app-build-suite"
           push_to_oci_registry: true
           requires:
-            - push-dex-app-to-quay
-            - push-dex-app-to-docker
-          # Trigger job on git tag.
+            - push-to-registries
           filters:
             tags:
               only: /^v.*/
@@ -124,9 +94,7 @@ workflows:
           chart: dex-app
           executor: "app-build-suite"
           requires:
-            - push-dex-app-to-quay
-            - push-dex-app-to-docker
-          # Trigger job on git tag.
+            - push-to-registries
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [x] Assign this PR to yourself
- [x] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [x] Double-check the job dependecies (`requires`)
- [x] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [x] Update the changelog if you think this deserves a mention
- [x] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!