### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [1.42.2] - 2023-11-30
 
 ### Changed
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adding new properties to configure trusted peers in pre-defined static clients 
+- Adding new properties to configure trusted peers in pre-defined static clients
 
 ## [1.42.0] - 2023-11-15
 
@@ -162,23 +166,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Added support for polymorphic values of `managementCluster` - it can be defined either as `string` or as `object`.
+- Add circle ci job to push to `gcp-app-collection` on new release.
 
 ## [1.30.1] - 2022-11-07
-
-## Added
-
-- Add support for array of connectors for `giantswarm`.
 
 ## [1.30.0] - 2022-10-13
 
 ### Changed
 
 - Update Dex to v2.35.3
-
-## Added
-
-- Add circle ci job to push to `gcp-app-collection` on new release.
 
 ## [1.29.0] - 2022-09-26
 
@@ -496,7 +492,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use `dex` `v2.24.0-giantswarm` tag, which includes Microsoft OIDC connector `offline_scope` fix (https://github.com/dexidp/dex/pull/1441).
-
 
 ## [1.0.0] - 2020-05-05
 

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -88,7 +88,7 @@ services:
     address: ""
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 # Giant Swarm properties for management clusters
 isManagementCluster: false


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
