### PR TITLE
app.kubernetes.io/instance removal

### DIFF
--- a/helm/dex-app/templates/_helpers.tpl
+++ b/helm/dex-app/templates/_helpers.tpl
@@ -32,7 +32,6 @@ Selector dex labels
 {{- define "dex.labels.selector" -}}
 app.kubernetes.io/name: {{ include "dex.name" . }}
 app.kubernetes.io/component: {{ include "dex.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## Changes
- Removes app.kubernetes.io/instance from podSelector as it exists in common labels.

## Checklist

- [ ] Update CHANGELOG.md
