### PR TITLE
remove-gs-monitoring-annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove deprecated giant swarm monitoring annotations and labels
+
 ## [1.42.8] - 2024-02-05
 
 ### Changed

--- a/helm/dex-app/templates/dex/service.yaml
+++ b/helm/dex-app/templates/dex/service.yaml
@@ -4,10 +4,6 @@ metadata:
   name: {{ include "resource.dex.name" . }}
   labels:
     {{- include "dex.labels.common" . | nindent 4 }}
-    giantswarm.io/monitoring: "true"
-  annotations:
-    giantswarm.io/monitoring-path: "/metrics"
-    giantswarm.io/monitoring-port: "5558"
 spec:
   type: ClusterIP
   sessionAffinity: None


### PR DESCRIPTION
The labels and annotations are redundant and dex is currently monitored twice on MCs with the Service Monitor by the prometheus agents and by the MC prometheus

## Checklist

- [x] Update CHANGELOG.md
