### PR TITLE
Default cluster issuer to `letsencrypt-giantswarm` and update ingress annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Default `ingress.tls.clusterIssuer` values to `letsencrypt-giantswarm`
-- Update `cert-manager.io/cluster-issuer` annotation for ingress to get from values.
+- Update `cert-manager.io/cluster-issuer` annotation to use default.
 
 ## [1.42.10] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default `ingress.tls.clusterIssuer` values to `letsencrypt-giantswarm`
+- Update `cert-manager.io/cluster-issuer` annotation for ingress to get from values.
+
 ## [1.42.10] - 2024-05-28
 
 ### Removed

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -11,11 +11,7 @@ metadata:
   labels:
     {{- include "dexk8sauth.labels.common" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.tls.letsencrypt }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
-    {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
-    {{- end }}
     {{- if .Values.ingress.externalDNS }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     external-dns.alpha.kubernetes.io/hostname: login.{{ .Values.baseDomain }}

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "dexk8sauth.labels.common" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.tls.letsencrypt }}
-    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "dex.labels.common" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.tls.letsencrypt }}
-    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -9,11 +9,7 @@ metadata:
   labels:
     {{- include "dex.labels.common" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.tls.letsencrypt }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
-    {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
-    {{- end }}
     {{- if .Values.ingress.externalDNS }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     external-dns.alpha.kubernetes.io/hostname: dex.{{ .Values.baseDomain }}

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -25,7 +25,7 @@ ingress:
   externalDNS: false
   tls:
     letsencrypt: true
-    clusterIssuer: ""
+    clusterIssuer: "letsencrypt-giantswarm"
     caPemB64: ""
     crtPemB64: ""
     keyPemB64: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/flexshopper/issues/458

- Default `ingress.tls.clusterIssuer` values to `letsencrypt-giantswarm`
- Update `cert-manager.io/cluster-issuer` annotation to use default.

## Checklist

- [x] Update CHANGELOG.md
