### PR TITLE
chart: make ingress annotations configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added renovate configutarion
+- Added renovate configuration
+- Make Ingress annotations configurable via values (`.Values.ingress.annotations`)
 
 ### Removed
 

--- a/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
+++ b/helm/dex-app/templates/dex-k8s-authenticator/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
     {{- end }}
     giantswarm.io/external-dns: managed
     {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   tls:

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- end }}
     giantswarm.io/external-dns: managed
     {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   tls:

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -122,6 +122,9 @@
                             }
                         }
                     }
+                },
+                "annotations": {
+                    "type": "object"
                 }
             }
         },

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -31,6 +31,7 @@ ingress:
     keyPemB64: ""
     externalSecret:
       enabled: false
+  annotations: {}
 
 oidc:
   issuerAddress: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33146

### Summary

Make the Ingress resource's annotations configurable, to allow for more flexible configuration of this app.

## Checklist

- [x] Update CHANGELOG.md
