### PR TITLE
Add conditional for snipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Added `largeHeaderBuffers` to ingress for large request header size.
+
 ## [1.42.14] - 2025-05-06
 
 ### Added

--- a/helm/dex-app/templates/dex/ingress.yaml
+++ b/helm/dex-app/templates/dex/ingress.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- include "dex.labels.common" . | nindent 4 }}
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
+    {{- if .Values.ingress.largeHeaderBuffers }}
     nginx.ingress.kubernetes.io/server-snippet: large_client_header_buffers 4 32k;
+    {{- end }}
     {{- if .Values.ingress.externalDNS }}
     {{- if eq (include "is-workload-cluster" .) "true" }}
     external-dns.alpha.kubernetes.io/hostname: dex.{{ .Values.baseDomain }}

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -90,10 +90,13 @@
             "type": "object",
             "properties": {
                 "externalDNS": {
-                    "type": "boolean"
+                  "type": "boolean"
                 },
                 "ingressClassName": {
                     "type": "string"
+                },
+                "largeHeaderBuffers": {
+                    "type": "boolean"
                 },
                 "tls": {
                     "type": "object",

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -23,6 +23,7 @@ logoURI: https://s.giantswarm.io/brand/1/logo.svg
 ingress:
   ingressClassName: "nginx"
   externalDNS: false
+  largeHeaderBuffers: false
   tls:
     letsencrypt: true
     clusterIssuer: "letsencrypt-giantswarm"


### PR DESCRIPTION
Some nginx ingress deployments have validation that blocks server snippets:

```
Upgrade "dex-app" failed: cannot patch "dex" with kind Ingress: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: nginx.ingress.kubernetes.io/server-snippet annotation cannot be used. Snippet directives are disabled by the Ingress administrator
```

## Checklist

- [x] Update CHANGELOG.md
