### PR TITLE
Extend managementCluster schema to allow for both object and string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow for `managementCluster` value to be a `string` or `object`.
+
 ## [2.0.1] - 2025-06-25
 
 ### Changed

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -634,7 +634,7 @@
       "description": "Whether this is a management cluster"
     },
     "managementCluster": {
-      "type": "object",
+      "type": ["object", "string"],
       "properties": {
         "name": {
           "type": "string",


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/33728