### PR TITLE
Set validOfNotUsedFor to 30 days

### DIFF
--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -152,9 +152,9 @@ oidc:
     signingKeys: 6h
     idTokens: 30m
     refreshTokens:
-      reuseInterval: "3s"
-      validIfNotUsedFor: "12h"
-      absoluteLifetime: "720h"
+      reuseInterval: 3s
+      validIfNotUsedFor: 720h
+      absoluteLifetime: 720h
   staticClients:
     gitopsui:
       clientID: ""


### PR DESCRIPTION
As `validIfNotUsedFor` seems to be limiting the token lifetime (overriding absoluteLifetime), this PR updates the default value to the intended 30 days.

## Checklist

- [ ] Update CHANGELOG.md
