### PR TITLE
fix: Disable refresh token rotation to prevent GitHub connector auth failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix support for using a private CA in the ingresses
-- Disable refresh token rotation by default (`oidc.expiry.refreshTokens.disableRotation: true`) to prevent "token already claimed" errors with GitHub connector and concurrent sessions.
-- Increase `oidc.expiry.refreshTokens.reuseInterval` from 3s to 30s as additional protection for concurrent sessions.
-- Increase `oidc.expiry.idTokens` from 30m to 24h to reduce refresh frequency and minimize upstream identity provider token rotation issues.
+- Increase `oidc.expiry.idTokens` from 30m to 720h (30 days) to match refresh token lifetime. This prevents token refresh which fails with GitHub connector due to upstream GitHub access tokens expiring after 8 hours.
 
 ## [2.1.2] - 2025-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix support for using a private CA in the ingresses
+- Disable refresh token rotation by default (`oidc.expiry.refreshTokens.disableRotation: true`) to prevent "token already claimed" errors with GitHub connector and concurrent sessions.
+- Increase `oidc.expiry.refreshTokens.reuseInterval` from 3s to 30s as additional protection for concurrent sessions.
+- Increase `oidc.expiry.idTokens` from 30m to 24h to reduce refresh frequency and minimize upstream identity provider token rotation issues.
 
 ## [2.1.2] - 2025-10-07
 

--- a/helm/dex-app/templates/secret-gs.yaml
+++ b/helm/dex-app/templates/secret-gs.yaml
@@ -48,9 +48,6 @@ stringData:
       idTokens: "{{ .Values.oidc.expiry.idTokens }}"
       {{- if .Values.oidc.expiry.refreshTokens }}
       refreshTokens:
-        {{- if .Values.oidc.expiry.refreshTokens.disableRotation }}
-        disableRotation: {{ .Values.oidc.expiry.refreshTokens.disableRotation }}
-        {{- end }}
         {{- if .Values.oidc.expiry.refreshTokens.reuseInterval }}
         reuseInterval: "{{ .Values.oidc.expiry.refreshTokens.reuseInterval }}"
         {{- end }}

--- a/helm/dex-app/templates/secret-gs.yaml
+++ b/helm/dex-app/templates/secret-gs.yaml
@@ -48,6 +48,9 @@ stringData:
       idTokens: "{{ .Values.oidc.expiry.idTokens }}"
       {{- if .Values.oidc.expiry.refreshTokens }}
       refreshTokens:
+        {{- if .Values.oidc.expiry.refreshTokens.disableRotation }}
+        disableRotation: {{ .Values.oidc.expiry.refreshTokens.disableRotation }}
+        {{- end }}
         {{- if .Values.oidc.expiry.refreshTokens.reuseInterval }}
         reuseInterval: "{{ .Values.oidc.expiry.refreshTokens.reuseInterval }}"
         {{- end }}

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -439,22 +439,17 @@
             },
             "idTokens": {
               "type": "string",
-              "description": "ID tokens expiry duration. Longer values reduce refresh frequency but tokens remain valid longer if compromised. Default: 24h",
-              "default": "24h"
+              "description": "ID tokens expiry duration. Set to match refresh token lifetime to avoid token refresh which fails with GitHub connector. Default: 720h (30 days)",
+              "default": "720h"
             },
             "refreshTokens": {
               "type": "object",
               "description": "Refresh token configuration",
               "properties": {
-                "disableRotation": {
-                  "type": "boolean",
-                  "description": "Disable refresh token rotation. When true, the same refresh token is reused until expiration, preventing 'token already claimed' errors with concurrent sessions or upstream provider token conflicts. Default: true",
-                  "default": true
-                },
                 "reuseInterval": {
                   "type": "string",
-                  "description": "Allow the same refresh token to be reused within this interval. Fallback for clients that might still trigger rotation. Default: 30s",
-                  "default": "30s"
+                  "description": "Allow the same refresh token to be reused within this interval. Default: 3s",
+                  "default": "3s"
                 },
                 "validIfNotUsedFor": {
                   "type": "string",

--- a/helm/dex-app/values.schema.json
+++ b/helm/dex-app/values.schema.json
@@ -431,6 +431,7 @@
         },
         "expiry": {
           "type": "object",
+          "description": "Token expiry configuration",
           "properties": {
             "signingKeys": {
               "type": "string",
@@ -438,7 +439,34 @@
             },
             "idTokens": {
               "type": "string",
-              "description": "ID tokens expiry duration"
+              "description": "ID tokens expiry duration. Longer values reduce refresh frequency but tokens remain valid longer if compromised. Default: 24h",
+              "default": "24h"
+            },
+            "refreshTokens": {
+              "type": "object",
+              "description": "Refresh token configuration",
+              "properties": {
+                "disableRotation": {
+                  "type": "boolean",
+                  "description": "Disable refresh token rotation. When true, the same refresh token is reused until expiration, preventing 'token already claimed' errors with concurrent sessions or upstream provider token conflicts. Default: true",
+                  "default": true
+                },
+                "reuseInterval": {
+                  "type": "string",
+                  "description": "Allow the same refresh token to be reused within this interval. Fallback for clients that might still trigger rotation. Default: 30s",
+                  "default": "30s"
+                },
+                "validIfNotUsedFor": {
+                  "type": "string",
+                  "description": "Refresh token expires if not used within this duration. Default: 720h (30 days)",
+                  "default": "720h"
+                },
+                "absoluteLifetime": {
+                  "type": "string",
+                  "description": "Absolute lifetime of refresh tokens regardless of activity. Default: 720h (30 days)",
+                  "default": "720h"
+                }
+              }
             }
           }
         },

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -150,25 +150,14 @@ oidc:
   issuerAddress: ""
   expiry:
     signingKeys: 6h
-    # ID token lifetime. Longer values reduce refresh frequency but tokens
-    # remain valid longer if compromised. 24h balances security with usability
-    # for interactive kubectl sessions.
-    idTokens: 24h
+    # ID token lifetime set to match refresh token lifetime (30 days).
+    # This avoids triggering token refresh which fails with GitHub connector
+    # due to upstream GitHub access tokens expiring after 8 hours.
+    # Users will re-authenticate when the session expires instead of refreshing.
+    idTokens: 720h
     refreshTokens:
-      # Disable refresh token rotation to prevent "token already claimed" errors.
-      # When rotation is enabled (default), each refresh generates a new token and
-      # invalidates the old one. This causes issues with:
-      # - Multiple concurrent kubectl sessions
-      # - GitHub connector token rotation conflicts
-      # - Race conditions between token refresh and storage
-      # With rotation disabled, the same refresh token is reused until expiration.
-      disableRotation: true
-      # Allow the same refresh token to be reused within this interval.
-      # This is a fallback for clients that might still trigger rotation.
-      reuseInterval: 30s
-      # Token expires if not used within 30 days
+      reuseInterval: 3s
       validIfNotUsedFor: 720h
-      # Absolute maximum lifetime of 30 days regardless of usage
       absoluteLifetime: 720h
   staticClients:
     gitopsui:

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -150,10 +150,25 @@ oidc:
   issuerAddress: ""
   expiry:
     signingKeys: 6h
-    idTokens: 30m
+    # ID token lifetime. Longer values reduce refresh frequency but tokens
+    # remain valid longer if compromised. 24h balances security with usability
+    # for interactive kubectl sessions.
+    idTokens: 24h
     refreshTokens:
-      reuseInterval: 3s
+      # Disable refresh token rotation to prevent "token already claimed" errors.
+      # When rotation is enabled (default), each refresh generates a new token and
+      # invalidates the old one. This causes issues with:
+      # - Multiple concurrent kubectl sessions
+      # - GitHub connector token rotation conflicts
+      # - Race conditions between token refresh and storage
+      # With rotation disabled, the same refresh token is reused until expiration.
+      disableRotation: true
+      # Allow the same refresh token to be reused within this interval.
+      # This is a fallback for clients that might still trigger rotation.
+      reuseInterval: 30s
+      # Token expires if not used within 30 days
       validIfNotUsedFor: 720h
+      # Absolute maximum lifetime of 30 days regardless of usage
       absoluteLifetime: 720h
   staticClients:
     gitopsui:


### PR DESCRIPTION

## Checklist

- [ ] Update CHANGELOG.md
