### PR TITLE
test(ats): tighten smoke-test timeout and rerun budget

### DIFF
--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 namespace_name = "default"
 
-timeout: int = 360
+timeout: int = 180
 
 
 @pytest.mark.smoke
@@ -66,7 +66,7 @@ def app_deployment(kube_cluster: Cluster) -> List[pykube.Deployment]:
 # this additional delay and retries
 @pytest.mark.smoke
 @pytest.mark.upgrade
-@pytest.mark.flaky(reruns=5, reruns_delay=10)
+@pytest.mark.flaky(reruns=1, reruns_delay=15)
 def test_pods_available(kube_cluster: Cluster, app_deployment: List[pykube.Deployment]):
     for d in app_deployment:
         assert int(d.obj["status"].get("readyReplicas", 0)) > 0


### PR DESCRIPTION
## Summary

The smoke-test ATS job worst-case runtime is dominated by the module-scoped `app_deployment` fixture being recreated on every flaky rerun. Each rerun pays the full readiness timeout, and the rerun budget is set to 5:

```
1 initial + 5 reruns = 6 attempts
6 × 360 s ≈ 36 min worst case
```

This PR:

- Cuts the per-attempt `timeout` from `360` → `180` (still ample for the dex Deployment in kind).
- Reduces `@pytest.mark.flaky(reruns=5, reruns_delay=10)` → `@pytest.mark.flaky(reruns=1, reruns_delay=15)`. One retry is enough for transient kube-API hiccups; `wait_for_objects_condition` is already a polling loop, so additional reruns don't shake anything loose.

Worst-case runtime drops from ~36 min to ~6 min while real failures still get a second chance.

This does **not** address why the deployment occasionally fails to become ready in CI — that's a separate issue.

Same fix as giantswarm/mcp-kubernetes#406; sibling PRs in `klaus`, `muster`, and `mcp-prometheus`.

Made with [Cursor](https://cursor.com)