### PR TITLE
fix: update dex to v2.43.1-gs4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        # dex base image is amd64-only; without a go-build job architect v9 would
+        # otherwise fall back to linux/amd64,linux/arm64 and fail on the arm64 base.
+        platforms: linux/amd64
         filters:
             # Trigger the job also on git tag.
           tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make log level configurable in Helm values.
 
+### Fixed
+
+- Update `dex` to `v2.43.1-gs4`. Fixes the OIDC connector dropping its `rootCAs`-aware HTTP client when `providerDiscoveryOverrides` is set, which caused RFC 8693 token-exchange subject-token verification to fetch JWKS over the system trust store and fail with `x509: certificate signed by unknown authority` for connectors whose issuer is served by a privately-trusted CA.
+
 ### Removed
 
 - Remove `push-to-app-collection` jobs from `.circleci/config.yml`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gsoci.azurecr.io/giantswarm/dex:v2.43.1-gs3
+FROM gsoci.azurecr.io/giantswarm/dex:v2.43.1-gs4
 
 ENV DEX_FRONTEND_DIR=/srv/dex/web
 


### PR DESCRIPTION
## Summary

- Bump the base image in `Dockerfile` from `dex:v2.43.1-gs3` to `dex:v2.43.1-gs4`.
- Picks up giantswarm/dex#74: the OIDC connector dropped its `rootCAs`-aware HTTP client when `providerDiscoveryOverrides` is set, so RFC 8693 token-exchange subject-token verification fetched JWKS over the system trust store and failed with `x509: certificate signed by unknown authority` for connectors whose issuer is served by a privately-trusted CA.

## Test plan

- [ ] CircleCI green (`push-to-registries`, chart push, ATS smoke test).
- [ ] After release tag, confirm `gsoci.azurecr.io/giantswarm/dex-app` image and chart publish.
- [ ] End-to-end: token-exchange against a connector with provider discovery overrides + a privately-trusted issuer succeeds.

Made with [Cursor](https://cursor.com)