### PR TITLE
chore: release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-06-18
+
 ### Changed
 
 - Make log level configurable in Helm values.
@@ -676,7 +678,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add helm chart for dex.
 
 
-[Unreleased]: https://github.com/giantswarm/dex-app/compare/v2.2.1...HEAD
+[Unreleased]: https://github.com/giantswarm/dex-app/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/giantswarm/dex-app/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/giantswarm/dex-app/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/giantswarm/dex-app/compare/v2.1.5...v2.2.0
 [2.1.5]: https://github.com/giantswarm/dex-app/compare/v2.1.4...v2.1.5

--- a/helm/dex-app/Chart.yaml
+++ b/helm/dex-app/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dex-app
-version: "2.2.1"
-appVersion: "2.2.1"
+version: "2.2.2"
+appVersion: "2.2.2"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
 keywords:
   - authentication

--- a/helm/dex-app/values.yaml
+++ b/helm/dex-app/values.yaml
@@ -8,7 +8,7 @@ dex:
       name: giantswarm/dex-app
       # Automatically synced from Chart.yaml appVersion via `make sync-image-tag`
       # Override only for testing with a specific image.
-      tag: "2.2.1"
+      tag: "2.2.2"
       pullPolicy: IfNotPresent
   configSecret:
     # -- Enable creating a secret from the values passed to `config`.


### PR DESCRIPTION
## Summary

Manual release of v2.2.2 (chart + appVersion + dex-app image tag), bundling the changes currently on `main`:

- `dex` updated to `v2.43.1-gs4` (giantswarm/dex#74): OIDC connector no longer drops its `rootCAs`-aware HTTP client when `providerDiscoveryOverrides` is set, fixing RFC 8693 token-exchange JWKS verification for privately-trusted issuers (`x509: certificate signed by unknown authority`).
- Log level configurable in Helm values.
- Removed `push-to-app-collection` jobs.

## Why manual

The shared `Create Release PR` workflow (`giantswarm/github-workflows` `create-release-pr.yaml@main`) currently fails: it installs the `architect` binary `v8.2.1`, but architect changed its release asset naming (now `architect-linux-amd64`, no longer `architect-v8.2.1-linux-amd64.tar.gz`), so `install-binary-action` 404s. This affects every repo's release PR, not just dex-app. This PR reproduces exactly what the bot would have produced; the tag will be created once merged so the CircleCI tag pipeline (architect orb) publishes the image + chart.

## Test plan

- [ ] Required check `push-to-control-plane-app-catalog` green.
- [ ] After tag, CircleCI publishes `gsoci.azurecr.io/giantswarm/dex-app:2.2.2` and the chart to the catalogs.

Made with [Cursor](https://cursor.com)