### PR TITLE
ci: split Aliyun push via sync-china-registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,27 @@ workflows:
         # dex base image is amd64-only; without a go-build job architect v9 would
         # otherwise fall back to linux/amd64,linux/arm64 and fail on the arm64 base.
         platforms: linux/amd64
+        # Push only to gsoci here; the gsoci -> Aliyun mirror is handled
+        # out-of-band by sync-china-registry below so the cross-Pacific push
+        # cannot time out and block the chart catalog publish.
+        split-china-push: true
         filters:
             # Trigger the job also on git tag.
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+            - master
+
+    # Mirror gsoci -> Aliyun via the in-China giantswarm/galaxy-runner. Runs out
+    # of band; an Aliyun mirror failure does NOT block the chart catalog publish.
+    - architect/sync-china-registry:
+        context: architect
+        name: sync-china-registry
+        requires:
+        - push-to-registries
+        filters:
           tags:
             only: /^v.*/
           branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI: push the release image to gsoci only and mirror to Aliyun out-of-band via `sync-china-registry`, so a slow cross-Pacific Aliyun push can no longer time out and block the chart catalog publish.
+
 ## [2.2.2] - 2026-06-18
 
 ### Changed


### PR DESCRIPTION
## Summary

The v2.2.2 tag pipeline's `push-to-registries` timed out on the cross-Pacific Aliyun push (10m no-output) after successfully pushing the image to gsoci, leaving the chart catalog jobs `not_run`. Enable the orb's `split-china-push` so the buildx push targets gsoci only, and add the companion `sync-china-registry` job to mirror gsoci -> Aliyun out-of-band on the in-China `galaxy-runner`.

This matches the established pattern in `klaus-operator`, `mcp-kubernetes`, `muster`, etc., and decouples the chart catalog publish from Aliyun availability.

## Test plan

- [ ] Branch build: `push-to-registries` (gsoci only) green; `sync-china-registry` runs out-of-band.
- [ ] Required check `push-to-control-plane-app-catalog` green.
- [ ] On the recreated `v2.2.2` tag, the chart publishes to the catalogs even if the Aliyun mirror is slow.

Made with [Cursor](https://cursor.com)