### PR TITLE
fix: update dex to v2.43.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CI: push the release image to gsoci only and mirror to Aliyun out-of-band via `sync-china-registry`, so a slow cross-Pacific Aliyun push can no longer time out and block the chart catalog publish.
 
+### Fixed
+
+- Update `dex` to `v2.43.2`. Fixes forced re-login after ~8h for GitHub App-backed connectors (GitHub App user-to-server tokens expire after 8 hours); the connector now persists GitHub's refresh token and renews the upstream user access token on refresh. Cherry-pick of upstream [dexidp/dex#4845](https://github.com/dexidp/dex/pull/4845).
+
 ## [2.2.2] - 2026-06-18
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gsoci.azurecr.io/giantswarm/dex:v2.43.1-gs4
+FROM gsoci.azurecr.io/giantswarm/dex:v2.43.2
 
 ENV DEX_FRONTEND_DIR=/srv/dex/web
 


### PR DESCRIPTION
## What

Bumps the dex image the dex-app chart is built from: `v2.43.1-gs4` → `v2.43.2` (`Dockerfile` `FROM`), plus a CHANGELOG entry.

## Why

Pulls in the GitHub connector refresh-token fix — cherry-pick of upstream [dexidp/dex#4845](https://github.com/dexidp/dex/pull/4845), released in [giantswarm/dex#78](https://github.com/giantswarm/dex/pull/78) as `v2.43.2`.

Fixes forced re-login after ~8h for GitHub App-backed connectors: GitHub App user-to-server tokens expire after 8 hours, and the old connector could not renew the upstream token on dex refresh, so sessions died at login+8h. The connector now persists GitHub's refresh token + expiry in `connectorData` and renews the upstream access token on `Refresh()`.

## Verification

`gsoci.azurecr.io/giantswarm/dex:v2.43.2` exists (built 2026-07-14, digest `sha256:3ce62221fdb39c04595dc52a3f1cec28906692cde0b1f61a14afa9424b5b8a74`).

## Rollout note

Existing GitHub-backed sessions only benefit after each user logs in once post-rollout — older `connectorData` has no upstream refresh token stored.

## Next

Release as `dex-app 2.2.3`, then bump `management-cluster-bases` (`bases/collections/shared/base/dex-app.yaml`) `2.2.2 → 2.2.3` to roll out to MCs.
